### PR TITLE
Qualify std Result

### DIFF
--- a/futures-async-macro/src/lib.rs
+++ b/futures-async-macro/src/lib.rs
@@ -200,7 +200,7 @@ pub fn async(attribute: TokenStream, function: TokenStream) -> TokenStream {
     syn::tokens::Semi([block.brace_token.0]).to_tokens(&mut result);
 
     let gen_body_inner = quote! {
-        let __e: Result<_, _> = #result
+        let __e: ::std::result::Result<_,_> = #result
 
         // Ensure that this closure is a generator, even if it doesn't
         // have any `yield` statements.


### PR DESCRIPTION
Using an unqualified `Result` clashes with types that are in scope with
the same name (e.g. by doing `use std::io::Result;`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alexcrichton/futures-await/24)
<!-- Reviewable:end -->
