### PR TITLE
#[async_stream] implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ fn fetch(client: hyper::Client, url: &'static str) -> io::Result<String> {
 fn fetch_all(client: hyper::Client, urls: Vec<&'static str>) -> io::Result<()> {
     for url in urls {
         let s = await!(fetch(client, url))?;
-        stream_yield!(Ok(s));
+        stream_yield!(s);
     }
     Ok(())
 }

--- a/README.md
+++ b/README.md
@@ -64,8 +64,7 @@ fn foo() -> io::Result<i32> {
 }
 ```
 
-And finally you can also have "async `for` loops" which operate over the
-[`Stream`] trait:
+You can also have "async `for` loops" which operate over the [`Stream`] trait:
 
 ```rust
 #[async]
@@ -77,6 +76,32 @@ for message in stream {
 An async `for` loop will propagate errors out of the function so `message` has
 the `Item` type of the `stream` passed in. Note that async `for` loops can only
 be used inside of an `#[async]` function.
+
+And finally, you can create a `Stream` instead of a `Future` via
+`#[async_stream(item = _)]`:
+
+```rust
+#[async]
+fn fetch(client: hyper::Client, url: &'static str) -> io::Result<String> {
+    // ...
+}
+
+/// Fetch all provided urls one at a time
+#[async_stream(item = String)]
+fn fetch_all(client: hyper::Client, urls: Vec<&'static str>) -> io::Result<()> {
+    for url in urls {
+        let s = await!(fetch(client, url))?;
+        stream_yield!(Ok(s));
+    }
+    Ok(())
+}
+```
+
+`#[async_stream]` must have an item type specified via `item = some::Path` and
+the values output from the stream must be wrapped into a `Result` and yielded
+via the `stream_yield!` macro.  This macro also supports the same features as
+`#[async]`, an additional `boxed` argument to return a `Box<Stream>`, async
+`for` loops, etc.
 
 [`Future`]: https://docs.rs/futures/0.1.13/futures/future/trait.Future.html
 [`Stream`]: https://docs.rs/futures/0.1.13/futures/stream/trait.Stream.html

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -29,12 +29,11 @@ fn main() {
     let server = async_block! {
         #[async]
         for (client, _) in tcp.incoming() {
-            handle.spawn(handle_client(client).then(|result| {
-                match result {
-                    Ok(n) => println!("wrote {} bytes", n),
-                    Err(e) => println!("IO error {:?}", e),
-                }
+            handle.spawn(handle_client(client).for_each(|n| {
+                println!("wrote {} bytes", n);
                 Ok(())
+            }).map_err(|e| {
+                println!("IO error {:?}", e);
             }));
         }
 
@@ -43,19 +42,17 @@ fn main() {
     core.run(server).unwrap();
 }
 
-#[async]
-fn handle_client(socket: TcpStream) -> io::Result<u64> {
+#[async_stream(item = "u64")]
+fn handle_client(socket: TcpStream) -> io::Result<()> {
     let (reader, mut writer) = socket.split();
     let input = BufReader::new(reader);
-
-    let mut total = 0;
 
     #[async]
     for line in tokio_io::io::lines(input) {
         println!("got client line: {}", line);
-        total += line.len() as u64;
+        stream_yield!(line.len() as u64);
         writer = await!(tokio_io::io::write_all(writer, line))?.0;
     }
 
-    Ok(total)
+    Ok(())
 }

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -42,7 +42,7 @@ fn main() {
     core.run(server).unwrap();
 }
 
-#[async_stream(item = "u64")]
+#[async_stream(item = u64)]
 fn handle_client(socket: TcpStream) -> io::Result<()> {
     let (reader, mut writer) = socket.split();
     let input = BufReader::new(reader);

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -50,7 +50,7 @@ fn handle_client(socket: TcpStream) -> io::Result<()> {
     #[async]
     for line in tokio_io::io::lines(input) {
         println!("got client line: {}", line);
-        stream_yield!(line.len() as u64);
+        stream_yield!(Ok(line.len() as u64));
         writer = await!(tokio_io::io::write_all(writer, line))?.0;
     }
 

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -50,7 +50,7 @@ fn handle_client(socket: TcpStream) -> io::Result<()> {
     #[async]
     for line in tokio_io::io::lines(input) {
         println!("got client line: {}", line);
-        stream_yield!(Ok(line.len() as u64));
+        stream_yield!(line.len() as u64);
         writer = await!(tokio_io::io::write_all(writer, line))?.0;
     }
 

--- a/futures-async-macro/Cargo.toml
+++ b/futures-async-macro/Cargo.toml
@@ -14,3 +14,7 @@ proc-macro2 = { version = "0.1", features = ["unstable"] }
 git = 'https://github.com/dtolnay/syn'
 features = ["full", "fold", "parsing", "printing"]
 default-features = false
+
+[dependencies.synom]
+git = 'https://github.com/dtolnay/syn'
+default-features = false

--- a/futures-async-macro/src/lib.rs
+++ b/futures-async-macro/src/lib.rs
@@ -488,11 +488,9 @@ impl synom::Synom for AsyncStreamArg {
 
 struct AsyncStreamArgs(Vec<AsyncStreamArg>);
 
-named!(async_stream_arg -> AsyncStreamArg, syn!(AsyncStreamArg));
-
 impl synom::Synom for AsyncStreamArgs {
     named!(parse -> Self, map!(
-        parens!(call!(Delimited::<_, syn::tokens::Comma>::parse_separated_nonempty_with, async_stream_arg)),
-        |d| AsyncStreamArgs(d.0.into_vec())
+        option!(parens!(call!(Delimited::<AsyncStreamArg, syn::tokens::Comma>::parse_separated_nonempty))),
+        |p| AsyncStreamArgs(p.map(|d| d.0.into_vec()).unwrap_or_default())
     ));
 }

--- a/futures-async-macro/src/lib.rs
+++ b/futures-async-macro/src/lib.rs
@@ -423,7 +423,12 @@ pub fn async_stream(attribute: TokenStream, function: TokenStream) -> TokenStrea
 
     let output_span = first_last(&output);
     let return_ty = if boxed {
-        unimplemented!()
+        quote! {
+            Box<::futures::Stream<
+                Item = !,
+                Error = <! as ::futures::__rt::IsResult>::Err,
+            >>
+        }
     } else {
         quote! { impl ::futures::__rt::MyStream<!, !> + 'static }
     };

--- a/futures-async-macro/src/lib.rs
+++ b/futures-async-macro/src/lib.rs
@@ -274,6 +274,9 @@ pub fn async_stream(attribute: TokenStream, function: TokenStream) -> TokenStrea
         match arg {
             AsyncStreamArg(term, None) => {
                 if term == "boxed" {
+                    if boxed {
+                        panic!("duplicate 'boxed' argument to #[async_stream]");
+                    }
                     boxed = true;
                 } else {
                     panic!("unexpected #[async_stream] argument '{}'", term);
@@ -281,6 +284,9 @@ pub fn async_stream(attribute: TokenStream, function: TokenStream) -> TokenStrea
             }
             AsyncStreamArg(term, Some(ty)) => {
                 if term == "item" {
+                    if item_ty.is_some() {
+                        panic!("duplicate 'item' argument to #[async_stream]");
+                    }
                     item_ty = Some(ty);
                 } else {
                     panic!("unexpected #[async_stream] argument '{}'", quote!(#term = #ty));

--- a/futures-async-macro/src/lib.rs
+++ b/futures-async-macro/src/lib.rs
@@ -279,11 +279,11 @@ pub fn async_stream(attribute: TokenStream, function: TokenStream) -> TokenStrea
                     panic!("unexpected #[async_stream] argument '{}'", term);
                 }
             }
-            AsyncStreamArg(term, Some(path)) => {
+            AsyncStreamArg(term, Some(ty)) => {
                 if term == "item" {
-                    item_ty = Some(path);
+                    item_ty = Some(ty);
                 } else {
-                    panic!("unexpected #[async_stream] argument '{}'", quote!(#term = #path));
+                    panic!("unexpected #[async_stream] argument '{}'", quote!(#term = #ty));
                 }
             }
         }
@@ -474,14 +474,14 @@ fn replace_bangs(input: proc_macro2::TokenStream, replacements: &[&ToTokens])
     new_tokens.into()
 }
 
-struct AsyncStreamArg(syn::Ident, Option<syn::Path>);
+struct AsyncStreamArg(syn::Ident, Option<syn::Ty>);
 
 impl synom::Synom for AsyncStreamArg {
     named!(parse -> Self, do_parse!(
         i: syn!(syn::Ident) >>
         p: option!(do_parse!(
             syn!(syn::tokens::Eq) >>
-            p: syn!(syn::Path) >>
+            p: syn!(syn::Ty) >>
             (p))) >>
         (AsyncStreamArg(i, p))));
 }

--- a/futures-await-macro/src/lib.rs
+++ b/futures-await-macro/src/lib.rs
@@ -22,7 +22,15 @@ macro_rules! await {
                     break ::futures::__rt::Err(e)
                 }
             }
-            yield
+            yield ::futures::Async::NotReady
         }
+    })
+}
+
+#[macro_export]
+macro_rules! stream_yield {
+    ($e:expr) => ({
+        let e = $e;
+        yield ::futures::Async::Ready(e)
     })
 }

--- a/futures-await-macro/src/lib.rs
+++ b/futures-await-macro/src/lib.rs
@@ -27,6 +27,9 @@ macro_rules! await {
     })
 }
 
+// TODO: This macro needs to use an extra temporary variable because of
+// rust-lang/rust#44197, once that's fixed this should just use $e directly
+// inside the yield expression
 #[macro_export]
 macro_rules! stream_yield {
     ($e:expr) => ({

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,8 +138,8 @@ pub mod __rt {
             match self.0.resume() {
                 GeneratorState::Yielded(Async::NotReady)
                     => Ok(Async::NotReady),
-                GeneratorState::Yielded(Async::Ready(_))
-                    => unreachable!("Mu doesn't exist"),
+                GeneratorState::Yielded(Async::Ready(mu))
+                    => match mu {},
                 GeneratorState::Complete(e)
                     => e.into_result().map(Async::Ready),
             }

--- a/testcrate/ui/bad-return-type.rs
+++ b/testcrate/ui/bad-return-type.rs
@@ -14,4 +14,16 @@ fn foobar() -> Result<Option<i32>, ()> {
     Ok(val)
 }
 
+#[async_stream(item = Option<i32>)]
+fn foobars() -> Result<(), ()> {
+    let val = Some(42);
+    if val.is_none() {
+        stream_yield!(Ok(None));
+        return Ok(())
+    }
+    let val = val.unwrap();
+    stream_yield!(Ok(val));
+    Ok(())
+}
+
 fn main() {}

--- a/testcrate/ui/bad-return-type.rs
+++ b/testcrate/ui/bad-return-type.rs
@@ -18,11 +18,11 @@ fn foobar() -> Result<Option<i32>, ()> {
 fn foobars() -> Result<(), ()> {
     let val = Some(42);
     if val.is_none() {
-        stream_yield!(Ok(None));
+        stream_yield!(None);
         return Ok(())
     }
     let val = val.unwrap();
-    stream_yield!(Ok(val));
+    stream_yield!(val);
     Ok(())
 }
 

--- a/testcrate/ui/bad-return-type.stderr
+++ b/testcrate/ui/bad-return-type.stderr
@@ -10,5 +10,29 @@ error[E0308]: mismatched types
    = note: expected type `std::option::Option<i32>`
               found type `{integer}`
 
-error: aborting due to previous error
+error[E0308]: mismatched types
+  --> $DIR/bad-return-type.rs:17:36
+   |
+17 |    #[async_stream(item = Option<i32>)]
+   |   ____________________________________^
+   |  |____________________________________|
+   | ||
+18 | || fn foobars() -> Result<(), ()> {
+19 | ||     let val = Some(42);
+20 | ||     if val.is_none() {
+...  ||
+24 | ||     let val = val.unwrap();
+25 | ||     stream_yield!(Ok(val));
+   | ||    ^
+   | ||____|
+   | |_____expected enum `std::option::Option`, found integral variable
+   |       help: try using a variant of the expected type: `Err(e)`
+   |
+   = note: expected type `std::result::Result<std::option::Option<_>, _>`
+              found type `std::result::Result<{integer}, _>`
+   = help: here are some functions which might fulfill your needs:
+           - .unwrap_err()
+   = note: this error originates in a macro outside of the current crate
+
+error: aborting due to 2 previous errors
 

--- a/testcrate/ui/bad-return-type.stderr
+++ b/testcrate/ui/bad-return-type.stderr
@@ -22,16 +22,14 @@ error[E0308]: mismatched types
 20 | ||     if val.is_none() {
 ...  ||
 24 | ||     let val = val.unwrap();
-25 | ||     stream_yield!(Ok(val));
+25 | ||     stream_yield!(val);
    | ||    ^
    | ||____|
    | |_____expected enum `std::option::Option`, found integral variable
-   |       help: try using a variant of the expected type: `Err(e)`
+   |       help: try using a variant of the expected type: `Some(e)`
    |
-   = note: expected type `std::result::Result<std::option::Option<_>, _>`
-              found type `std::result::Result<{integer}, _>`
-   = help: here are some functions which might fulfill your needs:
-           - .unwrap_err()
+   = note: expected type `std::option::Option<_>`
+              found type `{integer}`
    = note: this error originates in a macro outside of the current crate
 
 error: aborting due to 2 previous errors

--- a/testcrate/ui/borrowed-argument.rs
+++ b/testcrate/ui/borrowed-argument.rs
@@ -16,4 +16,12 @@ fn foo(a: String) -> Result<i32, u32> {
     Ok(1)
 }
 
+#[async_stream(item = i32)]
+fn foos(a: String) -> Result<(), u32> {
+    await!(bar(&a))?;
+    drop(a);
+    stream_yield!(Ok(5));
+    Ok(())
+}
+
 fn main() {}

--- a/testcrate/ui/borrowed-argument.rs
+++ b/testcrate/ui/borrowed-argument.rs
@@ -20,7 +20,7 @@ fn foo(a: String) -> Result<i32, u32> {
 fn foos(a: String) -> Result<(), u32> {
     await!(bar(&a))?;
     drop(a);
-    stream_yield!(Ok(5));
+    stream_yield!(5);
     Ok(())
 }
 

--- a/testcrate/ui/borrowed-argument.stderr
+++ b/testcrate/ui/borrowed-argument.stderr
@@ -9,5 +9,16 @@ error[E0597]: `a` does not live long enough
    |
    = note: borrowed value must be valid for the static lifetime...
 
-error: aborting due to previous error
+error[E0597]: `a` does not live long enough
+  --> $DIR/borrowed-argument.rs:21:17
+   |
+21 |     await!(bar(&a))?;
+   |                 ^ does not live long enough
+...
+25 | }
+   | - borrowed value only lives until here
+   |
+   = note: borrowed value must be valid for the static lifetime...
+
+error: aborting due to 2 previous errors
 

--- a/testcrate/ui/forget-ok.rs
+++ b/testcrate/ui/forget-ok.rs
@@ -8,4 +8,8 @@ use futures::prelude::*;
 fn foo() -> Result<(), ()> {
 }
 
+#[async_stream(item = i32)]
+fn foos() -> Result<(), ()> {
+}
+
 fn main() {}

--- a/testcrate/ui/forget-ok.stderr
+++ b/testcrate/ui/forget-ok.stderr
@@ -9,5 +9,16 @@ error[E0308]: mismatched types
   = note: expected type `std::result::Result<(), ()>`
              found type `()`
 
-error: aborting due to previous error
+error[E0308]: mismatched types
+  --> $DIR/forget-ok.rs:12:29
+   |
+12 |   fn foos() -> Result<(), ()> {
+   |  _____________________________^
+13 | | }
+   | |_^ expected enum `std::result::Result`, found ()
+   |
+   = note: expected type `std::result::Result<(), ()>`
+              found type `()`
+
+error: aborting due to 2 previous errors
 

--- a/testcrate/ui/generic-not-static.rs
+++ b/testcrate/ui/generic-not-static.rs
@@ -11,7 +11,7 @@ fn foo<T>(t: T) -> Result<T, u32> {
 
 #[async_stream(item = T)]
 fn foos<T>(t: T) -> Result<(), u32> {
-    stream_yield!(Ok(t));
+    stream_yield!(t);
     Ok(())
 }
 

--- a/testcrate/ui/generic-not-static.rs
+++ b/testcrate/ui/generic-not-static.rs
@@ -9,4 +9,15 @@ fn foo<T>(t: T) -> Result<T, u32> {
     Ok(t)
 }
 
+#[async_stream(item = T)]
+fn foos<T>(t: T) -> Result<(), u32> {
+    stream_yield!(Ok(t));
+    Ok(())
+}
+
+#[async_stream(item = i32)]
+fn foos2<T>(t: T) -> Result<(), u32> {
+    Ok(())
+}
+
 fn main() {}

--- a/testcrate/ui/generic-not-static.stderr
+++ b/testcrate/ui/generic-not-static.stderr
@@ -6,7 +6,7 @@ error[E0310]: the parameter type `T` may not live long enough
   |        |
   |        help: consider adding an explicit lifetime bound `T: 'static`...
   |
-note: ...so that the type `impl futures::__rt::MyFuture<<[generator@$DIR/generic-not-static.rs:8:35: 1:5 t:T (std::result::Result<T, u32>, ())] as std::ops::Generator>::Return>` will meet its required lifetime bounds
+note: ...so that the type `impl futures::__rt::MyFuture<<[generator@$DIR/generic-not-static.rs:8:35: 1:5 t:T (std::result::Result<T, u32>, futures::Async<futures::__rt::Mu>, ())] as std::ops::Generator>::Return>` will meet its required lifetime bounds
  --> $DIR/generic-not-static.rs:8:20
   |
 8 | fn foo<T>(t: T) -> Result<T, u32> {
@@ -20,7 +20,7 @@ error[E0310]: the parameter type `T` may not live long enough
   |        |
   |        help: consider adding an explicit lifetime bound `T: 'static`...
   |
-note: ...so that the type `impl futures::__rt::MyFuture<<[generator@$DIR/generic-not-static.rs:8:35: 1:5 t:T (std::result::Result<T, u32>, ())] as std::ops::Generator>::Return>` will meet its required lifetime bounds
+note: ...so that the type `impl futures::__rt::MyFuture<<[generator@$DIR/generic-not-static.rs:8:35: 1:5 t:T (std::result::Result<T, u32>, futures::Async<futures::__rt::Mu>, ())] as std::ops::Generator>::Return>` will meet its required lifetime bounds
  --> $DIR/generic-not-static.rs:8:20
   |
 8 | fn foo<T>(t: T) -> Result<T, u32> {

--- a/testcrate/ui/generic-not-static.stderr
+++ b/testcrate/ui/generic-not-static.stderr
@@ -26,5 +26,75 @@ note: ...so that the type `impl futures::__rt::MyFuture<<[generator@$DIR/generic
 8 | fn foo<T>(t: T) -> Result<T, u32> {
   |                    ^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error[E0310]: the parameter type `T` may not live long enough
+  --> $DIR/generic-not-static.rs:13:21
+   |
+13 | fn foos<T>(t: T) -> Result<(), u32> {
+   |         -           ^^^^^^^^^^^^^^^
+   |         |
+   |         help: consider adding an explicit lifetime bound `T: 'static`...
+   |
+note: ...so that the type `impl futures::__rt::MyStream<T, <[generator@$DIR/generic-not-static.rs:13:37: 1:5 t:T (std::result::Result<T, u32>, fn(std::result::Result<T, u32>) -> futures::Async<std::result::Result<T, u32>> {futures::Async<std::result::Result<T, u32>>::Ready}, futures::Async<std::result::Result<T, u32>>, (), std::result::Result<(), u32>)] as std::ops::Generator>::Return>` will meet its required lifetime bounds
+  --> $DIR/generic-not-static.rs:13:21
+   |
+13 | fn foos<T>(t: T) -> Result<(), u32> {
+   |                     ^^^^^^^^^^^^^^^
+
+error[E0310]: the parameter type `T` may not live long enough
+  --> $DIR/generic-not-static.rs:13:21
+   |
+13 | fn foos<T>(t: T) -> Result<(), u32> {
+   |         -           ^^^^^^^^^^^^^^^
+   |         |
+   |         help: consider adding an explicit lifetime bound `T: 'static`...
+   |
+note: ...so that the type `impl futures::__rt::MyStream<T, <[generator@$DIR/generic-not-static.rs:13:37: 1:5 t:T (std::result::Result<T, u32>, fn(std::result::Result<T, u32>) -> futures::Async<std::result::Result<T, u32>> {futures::Async<std::result::Result<T, u32>>::Ready}, futures::Async<std::result::Result<T, u32>>, (), std::result::Result<(), u32>)] as std::ops::Generator>::Return>` will meet its required lifetime bounds
+  --> $DIR/generic-not-static.rs:13:21
+   |
+13 | fn foos<T>(t: T) -> Result<(), u32> {
+   |                     ^^^^^^^^^^^^^^^
+
+error[E0310]: the parameter type `T` may not live long enough
+  --> $DIR/generic-not-static.rs:13:21
+   |
+13 | fn foos<T>(t: T) -> Result<(), u32> {
+   |         -           ^^^^^^^^^^^^^^^
+   |         |
+   |         help: consider adding an explicit lifetime bound `T: 'static`...
+   |
+note: ...so that the type `impl futures::__rt::MyStream<T, <[generator@$DIR/generic-not-static.rs:13:37: 1:5 t:T (std::result::Result<T, u32>, fn(std::result::Result<T, u32>) -> futures::Async<std::result::Result<T, u32>> {futures::Async<std::result::Result<T, u32>>::Ready}, futures::Async<std::result::Result<T, u32>>, (), std::result::Result<(), u32>)] as std::ops::Generator>::Return>` will meet its required lifetime bounds
+  --> $DIR/generic-not-static.rs:13:21
+   |
+13 | fn foos<T>(t: T) -> Result<(), u32> {
+   |                     ^^^^^^^^^^^^^^^
+
+error[E0310]: the parameter type `T` may not live long enough
+  --> $DIR/generic-not-static.rs:13:21
+   |
+13 | fn foos<T>(t: T) -> Result<(), u32> {
+   |         -           ^^^^^^^^^^^^^^^
+   |         |
+   |         help: consider adding an explicit lifetime bound `T: 'static`...
+   |
+note: ...so that the type `impl futures::__rt::MyStream<T, <[generator@$DIR/generic-not-static.rs:13:37: 1:5 t:T (std::result::Result<T, u32>, fn(std::result::Result<T, u32>) -> futures::Async<std::result::Result<T, u32>> {futures::Async<std::result::Result<T, u32>>::Ready}, futures::Async<std::result::Result<T, u32>>, (), std::result::Result<(), u32>)] as std::ops::Generator>::Return>` will meet its required lifetime bounds
+  --> $DIR/generic-not-static.rs:13:21
+   |
+13 | fn foos<T>(t: T) -> Result<(), u32> {
+   |                     ^^^^^^^^^^^^^^^
+
+error[E0310]: the parameter type `T` may not live long enough
+  --> $DIR/generic-not-static.rs:13:21
+   |
+13 | fn foos<T>(t: T) -> Result<(), u32> {
+   |         -           ^^^^^^^^^^^^^^^
+   |         |
+   |         help: consider adding an explicit lifetime bound `T: 'static`...
+   |
+note: ...so that the type `impl futures::__rt::MyStream<T, <[generator@$DIR/generic-not-static.rs:13:37: 1:5 t:T (std::result::Result<T, u32>, fn(std::result::Result<T, u32>) -> futures::Async<std::result::Result<T, u32>> {futures::Async<std::result::Result<T, u32>>::Ready}, futures::Async<std::result::Result<T, u32>>, (), std::result::Result<(), u32>)] as std::ops::Generator>::Return>` will meet its required lifetime bounds
+  --> $DIR/generic-not-static.rs:13:21
+   |
+13 | fn foos<T>(t: T) -> Result<(), u32> {
+   |                     ^^^^^^^^^^^^^^^
+
+error: aborting due to 7 previous errors
 

--- a/testcrate/ui/generic-not-static.stderr
+++ b/testcrate/ui/generic-not-static.stderr
@@ -34,7 +34,7 @@ error[E0310]: the parameter type `T` may not live long enough
    |         |
    |         help: consider adding an explicit lifetime bound `T: 'static`...
    |
-note: ...so that the type `impl futures::__rt::MyStream<T, <[generator@$DIR/generic-not-static.rs:13:37: 1:5 t:T (std::result::Result<T, u32>, fn(std::result::Result<T, u32>) -> futures::Async<std::result::Result<T, u32>> {futures::Async<std::result::Result<T, u32>>::Ready}, futures::Async<std::result::Result<T, u32>>, (), std::result::Result<(), u32>)] as std::ops::Generator>::Return>` will meet its required lifetime bounds
+note: ...so that the type `impl futures::__rt::MyStream<T, <[generator@$DIR/generic-not-static.rs:13:37: 1:5 t:T (T, fn(T) -> futures::Async<T> {futures::Async<T>::Ready}, futures::Async<T>, (), std::result::Result<(), u32>)] as std::ops::Generator>::Return>` will meet its required lifetime bounds
   --> $DIR/generic-not-static.rs:13:21
    |
 13 | fn foos<T>(t: T) -> Result<(), u32> {
@@ -48,7 +48,7 @@ error[E0310]: the parameter type `T` may not live long enough
    |         |
    |         help: consider adding an explicit lifetime bound `T: 'static`...
    |
-note: ...so that the type `impl futures::__rt::MyStream<T, <[generator@$DIR/generic-not-static.rs:13:37: 1:5 t:T (std::result::Result<T, u32>, fn(std::result::Result<T, u32>) -> futures::Async<std::result::Result<T, u32>> {futures::Async<std::result::Result<T, u32>>::Ready}, futures::Async<std::result::Result<T, u32>>, (), std::result::Result<(), u32>)] as std::ops::Generator>::Return>` will meet its required lifetime bounds
+note: ...so that the type `impl futures::__rt::MyStream<T, <[generator@$DIR/generic-not-static.rs:13:37: 1:5 t:T (T, fn(T) -> futures::Async<T> {futures::Async<T>::Ready}, futures::Async<T>, (), std::result::Result<(), u32>)] as std::ops::Generator>::Return>` will meet its required lifetime bounds
   --> $DIR/generic-not-static.rs:13:21
    |
 13 | fn foos<T>(t: T) -> Result<(), u32> {
@@ -62,7 +62,7 @@ error[E0310]: the parameter type `T` may not live long enough
    |         |
    |         help: consider adding an explicit lifetime bound `T: 'static`...
    |
-note: ...so that the type `impl futures::__rt::MyStream<T, <[generator@$DIR/generic-not-static.rs:13:37: 1:5 t:T (std::result::Result<T, u32>, fn(std::result::Result<T, u32>) -> futures::Async<std::result::Result<T, u32>> {futures::Async<std::result::Result<T, u32>>::Ready}, futures::Async<std::result::Result<T, u32>>, (), std::result::Result<(), u32>)] as std::ops::Generator>::Return>` will meet its required lifetime bounds
+note: ...so that the type `impl futures::__rt::MyStream<T, <[generator@$DIR/generic-not-static.rs:13:37: 1:5 t:T (T, fn(T) -> futures::Async<T> {futures::Async<T>::Ready}, futures::Async<T>, (), std::result::Result<(), u32>)] as std::ops::Generator>::Return>` will meet its required lifetime bounds
   --> $DIR/generic-not-static.rs:13:21
    |
 13 | fn foos<T>(t: T) -> Result<(), u32> {
@@ -76,7 +76,7 @@ error[E0310]: the parameter type `T` may not live long enough
    |         |
    |         help: consider adding an explicit lifetime bound `T: 'static`...
    |
-note: ...so that the type `impl futures::__rt::MyStream<T, <[generator@$DIR/generic-not-static.rs:13:37: 1:5 t:T (std::result::Result<T, u32>, fn(std::result::Result<T, u32>) -> futures::Async<std::result::Result<T, u32>> {futures::Async<std::result::Result<T, u32>>::Ready}, futures::Async<std::result::Result<T, u32>>, (), std::result::Result<(), u32>)] as std::ops::Generator>::Return>` will meet its required lifetime bounds
+note: ...so that the type `impl futures::__rt::MyStream<T, <[generator@$DIR/generic-not-static.rs:13:37: 1:5 t:T (T, fn(T) -> futures::Async<T> {futures::Async<T>::Ready}, futures::Async<T>, (), std::result::Result<(), u32>)] as std::ops::Generator>::Return>` will meet its required lifetime bounds
   --> $DIR/generic-not-static.rs:13:21
    |
 13 | fn foos<T>(t: T) -> Result<(), u32> {
@@ -90,7 +90,7 @@ error[E0310]: the parameter type `T` may not live long enough
    |         |
    |         help: consider adding an explicit lifetime bound `T: 'static`...
    |
-note: ...so that the type `impl futures::__rt::MyStream<T, <[generator@$DIR/generic-not-static.rs:13:37: 1:5 t:T (std::result::Result<T, u32>, fn(std::result::Result<T, u32>) -> futures::Async<std::result::Result<T, u32>> {futures::Async<std::result::Result<T, u32>>::Ready}, futures::Async<std::result::Result<T, u32>>, (), std::result::Result<(), u32>)] as std::ops::Generator>::Return>` will meet its required lifetime bounds
+note: ...so that the type `impl futures::__rt::MyStream<T, <[generator@$DIR/generic-not-static.rs:13:37: 1:5 t:T (T, fn(T) -> futures::Async<T> {futures::Async<T>::Ready}, futures::Async<T>, (), std::result::Result<(), u32>)] as std::ops::Generator>::Return>` will meet its required lifetime bounds
   --> $DIR/generic-not-static.rs:13:21
    |
 13 | fn foos<T>(t: T) -> Result<(), u32> {

--- a/testcrate/ui/missing-item.rs
+++ b/testcrate/ui/missing-item.rs
@@ -1,0 +1,13 @@
+#![allow(warnings)]
+#![feature(proc_macro, conservative_impl_trait, generators)]
+
+extern crate futures_await as futures;
+
+use futures::prelude::*;
+
+#[async_stream]
+fn foos(a: String) -> Result<(), u32> {
+    Ok(())
+}
+
+fn main() {}

--- a/testcrate/ui/missing-item.stderr
+++ b/testcrate/ui/missing-item.stderr
@@ -1,0 +1,8 @@
+error: custom attribute panicked
+ --> $DIR/missing-item.rs:8:1
+  |
+8 | #[async_stream]
+  | ^^^^^^^^^^^^^^^
+  |
+  = help: message: #[async_stream] requires item type to be specified
+

--- a/testcrate/ui/not-a-result.rs
+++ b/testcrate/ui/not-a-result.rs
@@ -14,4 +14,14 @@ fn bar() -> u32 {
     3
 }
 
+#[async_stream(item = u32)]
+fn foos() -> u32 {
+    3
+}
+
+#[async_stream(boxed, item = u32)]
+fn bars() -> u32 {
+    3
+}
+
 fn main() {}

--- a/testcrate/ui/not-a-result.stderr
+++ b/testcrate/ui/not-a-result.stderr
@@ -27,5 +27,34 @@ error[E0277]: the trait bound `u32: futures::__rt::IsResult` is not satisfied
    = help: the trait `futures::__rt::IsResult` is not implemented for `u32`
    = note: required by `futures::__rt::gen`
 
-error: aborting due to 3 previous errors
+error[E0277]: the trait bound `u32: futures::__rt::IsResult` is not satisfied
+  --> $DIR/not-a-result.rs:18:14
+   |
+18 | fn foos() -> u32 {
+   |              ^^^ async functions must return a `Result` or a typedef of `Result`
+   |
+   = help: the trait `futures::__rt::IsResult` is not implemented for `u32`
+   = note: required by `futures::__rt::gen_stream`
+
+error[E0277]: the trait bound `u32: futures::__rt::IsResult` is not satisfied
+  --> $DIR/not-a-result.rs:23:18
+   |
+23 |   fn bars() -> u32 {
+   |  __________________^
+24 | |     3
+25 | | }
+   | |_^ async functions must return a `Result` or a typedef of `Result`
+   |
+   = help: the trait `futures::__rt::IsResult` is not implemented for `u32`
+
+error[E0277]: the trait bound `u32: futures::__rt::IsResult` is not satisfied
+  --> $DIR/not-a-result.rs:23:14
+   |
+23 | fn bars() -> u32 {
+   |              ^^^ async functions must return a `Result` or a typedef of `Result`
+   |
+   = help: the trait `futures::__rt::IsResult` is not implemented for `u32`
+   = note: required by `futures::__rt::gen_stream`
+
+error: aborting due to 6 previous errors
 

--- a/testcrate/ui/unresolved-type.rs
+++ b/testcrate/ui/unresolved-type.rs
@@ -9,4 +9,9 @@ fn foo() -> Result<A, u32> {
     Err(3)
 }
 
+#[async_stream(item = A)]
+fn foos() -> Result<(), u32> {
+    Err(3)
+}
+
 fn main() {}

--- a/testcrate/ui/unresolved-type.stderr
+++ b/testcrate/ui/unresolved-type.stderr
@@ -14,5 +14,13 @@ error[E0412]: cannot find type `A` in this scope
   |
   = help: there is an enum variant `futures::future::Either::A`, try using `futures::future::Either`?
 
-error: aborting due to 2 previous errors
+error[E0412]: cannot find type `A` in this scope
+  --> $DIR/unresolved-type.rs:12:23
+   |
+12 | #[async_stream(item = A)]
+   |                       ^ not found in this scope
+   |
+   = help: there is an enum variant `futures::future::Either::A`, try using `futures::future::Either`?
+
+error: aborting due to 3 previous errors
 

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -180,3 +180,17 @@ fn loop_in_loop() -> Result<bool, i32> {
     let sum = (1..5).map(|x| (1..5).map(|y| x * y).sum::<i32>()).sum::<i32>();
     Ok(cnt == sum)
 }
+
+#[async_stream(item = i32)]
+fn poll_stream_after_error_stream() -> Result<(), ()> {
+    stream_yield!(Ok(5));
+    Err(())
+}
+
+#[test]
+fn poll_stream_after_error() {
+    let mut s = poll_stream_after_error_stream();
+    assert_eq!(s.poll(), Ok(Async::Ready(Some(5))));
+    assert_eq!(s.poll(), Err(()));
+    assert_eq!(s.poll(), Ok(Async::Ready(None)));
+}

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -86,6 +86,38 @@ fn _bar4() -> Result<i32, i32> {
     Ok(cnt)
 }
 
+#[async_stream(item = "u64")]
+fn _stream1() -> Result<(), i32> {
+    stream_yield!(Ok(0));
+    stream_yield!(Ok(1));
+    Ok(())
+}
+
+#[async_stream(item = "T")]
+fn _stream2<T: Clone + 'static>(t: T) -> Result<(), i32> {
+    stream_yield!(Ok(t.clone()));
+    stream_yield!(Ok(t.clone()));
+    Ok(())
+}
+
+#[async_stream(item = "i32")]
+fn _stream3() -> Result<(), i32> {
+    let mut cnt = 0;
+    #[async]
+    for x in futures::stream::iter_ok::<_, i32>(vec![1, 2, 3, 4]) {
+        cnt += x;
+        stream_yield!(Ok(x));
+    }
+    Err(cnt)
+}
+
+#[async_stream(boxed, item = "u64")]
+fn _stream4() -> Result<(), i32> {
+    stream_yield!(Ok(0));
+    stream_yield!(Ok(1));
+    Ok(())
+}
+
 // struct A(i32);
 //
 // impl A {

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -86,21 +86,21 @@ fn _bar4() -> Result<i32, i32> {
     Ok(cnt)
 }
 
-#[async_stream(item = "u64")]
+#[async_stream(item = u64)]
 fn _stream1() -> Result<(), i32> {
     stream_yield!(Ok(0));
     stream_yield!(Ok(1));
     Ok(())
 }
 
-#[async_stream(item = "T")]
+#[async_stream(item = T)]
 fn _stream2<T: Clone + 'static>(t: T) -> Result<(), i32> {
     stream_yield!(Ok(t.clone()));
     stream_yield!(Ok(t.clone()));
     Ok(())
 }
 
-#[async_stream(item = "i32")]
+#[async_stream(item = i32)]
 fn _stream3() -> Result<(), i32> {
     let mut cnt = 0;
     #[async]
@@ -111,10 +111,19 @@ fn _stream3() -> Result<(), i32> {
     Err(cnt)
 }
 
-#[async_stream(boxed, item = "u64")]
+#[async_stream(boxed, item = u64)]
 fn _stream4() -> Result<(), i32> {
     stream_yield!(Ok(0));
     stream_yield!(Ok(1));
+    Ok(())
+}
+
+mod foo { pub struct Foo(pub i32); }
+
+#[async_stream(boxed, item = foo::Foo)]
+pub fn _stream5() -> Result<(), i32> {
+    stream_yield!(Ok(foo::Foo(0)));
+    stream_yield!(Ok(foo::Foo(1)));
     Ok(())
 }
 

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -88,15 +88,15 @@ fn _bar4() -> Result<i32, i32> {
 
 #[async_stream(item = u64)]
 fn _stream1() -> Result<(), i32> {
-    stream_yield!(Ok(0));
-    stream_yield!(Ok(1));
+    stream_yield!(0);
+    stream_yield!(1);
     Ok(())
 }
 
 #[async_stream(item = T)]
 fn _stream2<T: Clone + 'static>(t: T) -> Result<(), i32> {
-    stream_yield!(Ok(t.clone()));
-    stream_yield!(Ok(t.clone()));
+    stream_yield!(t.clone());
+    stream_yield!(t.clone());
     Ok(())
 }
 
@@ -106,15 +106,15 @@ fn _stream3() -> Result<(), i32> {
     #[async]
     for x in futures::stream::iter_ok::<_, i32>(vec![1, 2, 3, 4]) {
         cnt += x;
-        stream_yield!(Ok(x));
+        stream_yield!(x);
     }
     Err(cnt)
 }
 
 #[async_stream(boxed, item = u64)]
 fn _stream4() -> Result<(), i32> {
-    stream_yield!(Ok(0));
-    stream_yield!(Ok(1));
+    stream_yield!(0);
+    stream_yield!(1);
     Ok(())
 }
 
@@ -122,8 +122,8 @@ mod foo { pub struct Foo(pub i32); }
 
 #[async_stream(boxed, item = foo::Foo)]
 pub fn stream5() -> Result<(), i32> {
-    stream_yield!(Ok(foo::Foo(0)));
-    stream_yield!(Ok(foo::Foo(1)));
+    stream_yield!(foo::Foo(0));
+    stream_yield!(foo::Foo(1));
     Ok(())
 }
 
@@ -131,20 +131,20 @@ pub fn stream5() -> Result<(), i32> {
 pub fn _stream6() -> Result<(), i32> {
     #[async]
     for foo::Foo(i) in stream5() {
-        stream_yield!(Ok(i * i));
+        stream_yield!(i * i);
     }
     Ok(())
 }
 
 #[async_stream(item = ())]
 pub fn _stream7() -> Result<(), i32> {
-    stream_yield!(Ok(()));
+    stream_yield!(());
     Ok(())
 }
 
 #[async_stream(item = [u32; 4])]
 pub fn _stream8() -> Result<(), i32> {
-    stream_yield!(Ok([1, 2, 3, 4]));
+    stream_yield!([1, 2, 3, 4]);
     Ok(())
 }
 
@@ -204,7 +204,7 @@ fn loop_in_loop() -> Result<bool, i32> {
 
 #[async_stream(item = i32)]
 fn poll_stream_after_error_stream() -> Result<(), ()> {
-    stream_yield!(Ok(5));
+    stream_yield!(5);
     Err(())
 }
 

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -121,9 +121,18 @@ fn _stream4() -> Result<(), i32> {
 mod foo { pub struct Foo(pub i32); }
 
 #[async_stream(boxed, item = foo::Foo)]
-pub fn _stream5() -> Result<(), i32> {
+pub fn stream5() -> Result<(), i32> {
     stream_yield!(Ok(foo::Foo(0)));
     stream_yield!(Ok(foo::Foo(1)));
+    Ok(())
+}
+
+#[async_stream(boxed, item = i32)]
+pub fn _stream6() -> Result<(), i32> {
+    #[async]
+    for foo::Foo(i) in stream5() {
+        stream_yield!(Ok(i * i));
+    }
     Ok(())
 }
 

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -136,6 +136,18 @@ pub fn _stream6() -> Result<(), i32> {
     Ok(())
 }
 
+#[async_stream(item = ())]
+pub fn _stream7() -> Result<(), i32> {
+    stream_yield!(Ok(()));
+    Ok(())
+}
+
+#[async_stream(item = [u32; 4])]
+pub fn _stream8() -> Result<(), i32> {
+    stream_yield!(Ok([1, 2, 3, 4]));
+    Ok(())
+}
+
 // struct A(i32);
 //
 // impl A {


### PR DESCRIPTION
Current usage is similar to

```rust
fn check_load() -> Result<(), &'static str> { ... }

fn prep_launchpad() -> impl Future<Item = (), Error = &'static str> { ... }

#[async_stream(item = u32)]
fn blast_off(abort: bool) -> Result<(), &'static str> {
    stream_yield!(3);
    check_load()?;
    stream_yield!(2);
    if abort {
        return Err("blast off aborted");
    }
    await!(prep_launchpad())?;
    stream_yield!(1);
    Ok(())
}
```

where the signature

```rust
#[async_stream(item = T)]
fn foo() -> Result<(), U>
```

is transformed into

```rust
fn foo() -> impl Stream<Item=T, Error=U>
```

`#[async_stream(boxed, item = T)]` is also supported

Major stuff that needs to happen before merging:
- ~~Decide if `never_type` feature is ok, or come up with an alternative method to make `await!` compatible with both `#[async]` and `#[async_stream]`~~ (EDIT: replaced with a local uninhabited type)
- ~~Rebase/merge latest changes~~ (EDIT: rebased)
- ~~Add tests~~ (EDIT: smoke tests added)
- ~~Pull out some helper methods to reduce duplication between `#[async]` and `#[async_stream]`~~ (EDIT: Replaced with a single helper implementation)

Fixes #7