### PR TITLE
Fix another `mismatched type __e` error

### DIFF
--- a/futures-await-async-macro/src/lib.rs
+++ b/futures-await-async-macro/src/lib.rs
@@ -196,7 +196,7 @@ fn async_inner<F>(
     let output_span = first_last(&output);
     let gen_function = respan(gen_function.into(), &output_span);
     let body_inner = quote! {
-        #gen_function (move || #gen_body)
+        #gen_function (move || -> #output #gen_body)
     };
     let body_inner = if boxed {
         let body = quote! { Box::new(#body_inner) };

--- a/testcrate/ui/bad-return-type.rs
+++ b/testcrate/ui/bad-return-type.rs
@@ -26,4 +26,12 @@ fn foobars() -> Result<(), ()> {
     Ok(())
 }
 
+#[async]
+fn tuple() -> Result<(i32, i32), ()> {
+    if false {
+        return Ok(3);
+    }
+    Ok((1, 2))
+}
+
 fn main() {}

--- a/testcrate/ui/bad-return-type.stderr
+++ b/testcrate/ui/bad-return-type.stderr
@@ -32,5 +32,14 @@ error[E0308]: mismatched types
               found type `{integer}`
    = note: this error originates in a macro outside of the current crate
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/bad-return-type.rs:32:19
+   |
+32 |         return Ok(3);
+   |                   ^ expected tuple, found integral variable
+   |
+   = note: expected type `(i32, i32)`
+              found type `{integer}`
+
+error: aborting due to 3 previous errors
 

--- a/testcrate/ui/unresolved-type.stderr
+++ b/testcrate/ui/unresolved-type.stderr
@@ -14,5 +14,5 @@ error[E0412]: cannot find type `A` in this scope
    |
    = help: there is an enum variant `futures::future::Either::A`, try using `futures::future::Either`?
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Hi,

I've found another example (similar to #33), which results in the following less helpful error: `mismatched type __e`.

```rust
#[async]
fn foobar() -> Result<(i32, i32), ()> {
    if false {
        return Ok(3);
    }
    Ok((1, 2))
}
```

Error:

```
error[E0308]: mismatched types
 --> <proc-macro source code>:1:1
  |
1 | __e
  | ^^^ expected integral variable, found tuple
  |
  = note: expected type `std::result::Result<{integer}, _>`
             found type `std::result::Result<(i32, i32), ()>`

error[E0271]: type mismatch resolving `<impl futures::__rt::MyFuture<<[generator@src/main.rs:7:39: 1:5 _] as std::ops::Generator>::Return> as futures::Future>::Item == (i32, i32)`
 --> src/main.rs:7:16
  |
7 | fn foobar() -> Result<(i32, i32), ()> {
  |                ^^^^^^^^^^^^^^^^^^^^^^ expected integral variable, found tuple
  |
  = note: expected type `{integer}`
             found type `(i32, i32)`
  = note: required because of the requirements on the impl of `futures::__rt::MyFuture<std::result::Result<(i32, i32), ()>>` for `impl futures::__rt::MyFuture<<[generator@src/main.rs:7:39: 1:5 _] as std::ops::Generator>::Return>`
  = note: the return type of a function must have a statically known size
```

With this PR, the error is:

```
error[E0308]: mismatched types
 --> src/main.rs:9:19
  |
9 |         return Ok(3);
  |                   ^ expected tuple, found integral variable
  |
  = note: expected type `(i32, i32)`
             found type `{integer}`
```

---

**Edit:** I've just applied this PR to a bigger project and it seems to have a bigger effect on the kind of reported errors than expected. For example errors like

```
error[E0271]: type mismatch resolving `<impl futures::__rt::MyFuture<<[generator@src/models/order.rs:324:57: 1:5 conn:_, order:_ _] as std::ops::Generator>::Return> as futures::Future>::Error == (postgres::Error, postgres_pool::Connection)`
   --> src/models/order.rs:324:6
    |
324 | ) -> Result<(Order, Connection), (DbError, Connection)> {
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `postgres_pool::Transaction`, found struct `postgres_pool::Connection`
    |
    = note: expected type `(postgres::Error, postgres_pool::Transaction)`
               found type `(postgres::Error, postgres_pool::Connection)`
    = note: required for the cast to the object type `futures::Future<Item=(models::order::Order, postgres_pool::Connection), Error=(postgres::Error, postgres_pool::Connection)>`
```

are gone and replaced with errors that point directly to the lines inside the function that return the wrong type.
