### PR TITLE
improve error reporting

### DIFF
--- a/futures-await-async-macro/src/lib.rs
+++ b/futures-await-async-macro/src/lib.rs
@@ -199,7 +199,7 @@ fn async_inner<F>(
         #gen_function (move || -> #output #gen_body)
     };
     let body_inner = if boxed {
-        let body = quote! { Box::new(#body_inner) };
+        let body = quote! { ::futures::__rt::std::boxed::Box::new(#body_inner) };
         respan(body.into(), &output_span)
     } else {
         body_inner.into()
@@ -240,7 +240,7 @@ pub fn async(attribute: TokenStream, function: TokenStream) -> TokenStream {
         let output_span = first_last(&output);
         let return_ty = if boxed {
             quote! {
-                Box<::futures::Future<
+                ::futures::__rt::std::boxed::Box<::futures::Future<
                     Item = <! as ::futures::__rt::IsResult>::Ok,
                     Error = <! as ::futures::__rt::IsResult>::Err,
                 >>
@@ -302,7 +302,7 @@ pub fn async_stream(attribute: TokenStream, function: TokenStream) -> TokenStrea
         let output_span = first_last(&output);
         let return_ty = if boxed {
             quote! {
-                Box<::futures::Stream<
+                ::futures::__rt::std::boxed::Box<::futures::Stream<
                     Item = !,
                     Error = <! as ::futures::__rt::IsResult>::Err,
                 >>
@@ -407,8 +407,8 @@ impl Folder for ExpandAsyncFor {
                     match r {
                         futures_await::Async::Ready(e) => {
                             match e {
-                                futures_await::__rt::Some(e) => e,
-                                futures_await::__rt::None => break,
+                                futures_await::__rt::std::option::Option::Some(e) => e,
+                                futures_await::__rt::std::option::Option::None => break,
                             }
                         }
                         futures_await::Async::NotReady => {

--- a/futures-await-await-macro/src/lib.rs
+++ b/futures-await-await-macro/src/lib.rs
@@ -14,12 +14,12 @@ macro_rules! await {
         let mut future = $e;
         loop {
             match ::futures::Future::poll(&mut future) {
-                ::futures::__rt::Ok(::futures::Async::Ready(e)) => {
-                    break ::futures::__rt::Ok(e)
+                ::futures::__rt::std::result::Result::Ok(::futures::Async::Ready(e)) => {
+                    break ::futures::__rt::std::result::Result::Ok(e)
                 }
-                ::futures::__rt::Ok(::futures::Async::NotReady) => {}
-                ::futures::__rt::Err(e) => {
-                    break ::futures::__rt::Err(e)
+                ::futures::__rt::std::result::Result::Ok(::futures::Async::NotReady) => {}
+                ::futures::__rt::std::result::Result::Err(e) => {
+                    break ::futures::__rt::std::result::Result::Err(e)
                 }
             }
             yield ::futures::Async::NotReady

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,9 +40,7 @@ pub mod prelude {
 /// your code to be stable.
 #[doc(hidden)]
 pub mod __rt {
-    pub use std::boxed::Box;
-    pub use std::option::Option::{Some, None};
-    pub use std::result::Result::{Ok, Err, self};
+    pub extern crate std;
     pub use std::ops::Generator;
 
     use futures::Poll;

--- a/testcrate/ui/bad-return-type.stderr
+++ b/testcrate/ui/bad-return-type.stderr
@@ -5,7 +5,7 @@ error[E0308]: mismatched types
    |        ^^^
    |        |
    |        expected enum `std::option::Option`, found integral variable
-   |        help: try using a variant of the expected type: `futures::__rt::Some(val)`
+   |        help: try using a variant of the expected type: `Some(val)`
    |
    = note: expected type `std::option::Option<i32>`
               found type `{integer}`
@@ -26,7 +26,7 @@ error[E0308]: mismatched types
    | ||    ^
    | ||____|
    | |_____expected enum `std::option::Option`, found integral variable
-   |       help: try using a variant of the expected type: `futures::__rt::Some(e)`
+   |       help: try using a variant of the expected type: `Some(e)`
    |
    = note: expected type `std::option::Option<_>`
               found type `{integer}`

--- a/testcrate/ui/forget-ok.stderr
+++ b/testcrate/ui/forget-ok.stderr
@@ -4,9 +4,9 @@ error[E0308]: mismatched types
 8 |   fn foo() -> Result<(), ()> {
   |  ____________________________^
 9 | | }
-  | |_^ expected enum `futures::__rt::Result`, found ()
+  | |_^ expected enum `std::result::Result`, found ()
   |
-  = note: expected type `futures::__rt::Result<(), ()>`
+  = note: expected type `std::result::Result<(), ()>`
              found type `()`
 
 error[E0308]: mismatched types
@@ -15,9 +15,9 @@ error[E0308]: mismatched types
 12 |   fn foos() -> Result<(), ()> {
    |  _____________________________^
 13 | | }
-   | |_^ expected enum `futures::__rt::Result`, found ()
+   | |_^ expected enum `std::result::Result`, found ()
    |
-   = note: expected type `futures::__rt::Result<(), ()>`
+   = note: expected type `std::result::Result<(), ()>`
               found type `()`
 
 error: aborting due to 2 previous errors

--- a/testcrate/ui/generic-not-static.stderr
+++ b/testcrate/ui/generic-not-static.stderr
@@ -6,7 +6,7 @@ error[E0310]: the parameter type `T` may not live long enough
   |        |
   |        help: consider adding an explicit lifetime bound `T: 'static`...
   |
-note: ...so that the type `impl futures::__rt::MyFuture<<[generator@$DIR/generic-not-static.rs:8:35: 1:5 t:T (futures::__rt::Result<T, u32>, futures::Async<futures::__rt::Mu>, ())] as futures::__rt::Generator>::Return>` will meet its required lifetime bounds
+note: ...so that the type `impl futures::__rt::MyFuture<<[generator@$DIR/generic-not-static.rs:8:35: 1:5 t:T (std::result::Result<T, u32>, futures::Async<futures::__rt::Mu>, ())] as futures::__rt::Generator>::Return>` will meet its required lifetime bounds
  --> $DIR/generic-not-static.rs:8:20
   |
 8 | fn foo<T>(t: T) -> Result<T, u32> {
@@ -20,7 +20,7 @@ error[E0310]: the parameter type `T` may not live long enough
    |         |
    |         help: consider adding an explicit lifetime bound `T: 'static`...
    |
-note: ...so that the type `impl futures::__rt::MyStream<T, <[generator@$DIR/generic-not-static.rs:13:37: 1:5 t:T (T, fn(T) -> futures::Async<T> {futures::Async<T>::Ready}, futures::Async<T>, (), futures::__rt::Result<(), u32>)] as futures::__rt::Generator>::Return>` will meet its required lifetime bounds
+note: ...so that the type `impl futures::__rt::MyStream<T, <[generator@$DIR/generic-not-static.rs:13:37: 1:5 t:T (T, fn(T) -> futures::Async<T> {futures::Async<T>::Ready}, futures::Async<T>, (), std::result::Result<(), u32>)] as futures::__rt::Generator>::Return>` will meet its required lifetime bounds
   --> $DIR/generic-not-static.rs:13:21
    |
 13 | fn foos<T>(t: T) -> Result<(), u32> {


### PR DESCRIPTION
 - show std instead of futures::__rt

e.g. `std::result::Result` / `Ok` / `Err` instead of `futures::__rt::Result` / `futures::__rt::Ok` / `futures::__rt::Err`

r? @alexcrichton 