### PR TITLE
Type annotations

### DIFF
--- a/futures-await-async-macro/src/type_ann.rs
+++ b/futures-await-async-macro/src/type_ann.rs
@@ -1,0 +1,109 @@
+//! Creates type annotations for yield and return.
+use syn::*;
+use quote::{ToTokens, Tokens};
+use std::iter;
+
+pub trait TypeData {
+    fn set_output(&mut self, output: &Type);
+    /// This method returns vec because two annotation is required.
+    ///
+    /// For future, first one is `Result<_, _>` which allows rustc to say
+    ///  `return type should be Result` regardless of user-defined return type.
+    ///
+    ///
+    fn annotate_return_type(&mut self) -> Vec<Type>;
+    fn annotate_yield_type(&mut self) -> Vec<Type>;
+}
+pub struct Future {
+    /// Some for #[async] and None for async_block.
+    pub output: Option<Type>,
+}
+
+pub struct Stream {
+    /// Some for #[async_stream] and None for async_stream_block.
+    pub output: Option<Type>,
+    /// Some for #[async_stream] and None for async_stream_block.
+    pub item: Option<Type>,
+}
+
+fn parse_ty(t: Tokens) -> Type {
+    parse(t.into()).expect("failed to parse type")
+}
+/// Alternative way to clone
+pub fn reparse(ty: &Type) -> Type {
+    let mut tokens = Tokens::new();
+    ty.to_tokens(&mut tokens);
+    parse_ty(tokens)
+}
+
+impl TypeData for Future {
+    fn set_output(&mut self, output: &Type) {
+        self.output = Some(reparse(output));
+    }
+    fn annotate_return_type(&mut self) -> Vec<Type> {
+        iter::once({
+            // this should come first because rustc always prefer the first one.
+            parse_ty(quote_cs!(::futures::__rt::std::result::Result<_, _>))
+        }).chain(self.output.take())
+            .collect()
+    }
+    fn annotate_yield_type(&mut self) -> Vec<Type> {
+        vec![parse_ty(quote_cs!(::futures::Async<::futures::__rt::Mu>))]
+    }
+}
+
+impl TypeData for Stream {
+    fn set_output(&mut self, output: &Type) {
+        self.output = Some(reparse(output));
+    }
+    fn annotate_return_type(&mut self) -> Vec<Type> {
+        iter::once(parse_ty(
+            quote_cs!(::futures::__rt::std::result::Result<(), _>),
+        )).chain(self.output.take())
+            .collect()
+    }
+    fn annotate_yield_type(&mut self) -> Vec<Type> {
+        iter::once(parse_ty(quote_cs!(::futures::Async<_>)))
+            .chain(
+                self.item
+                    .take()
+                    .map(|item_ty| parse_ty(quote_cs!(::futures::Async<#item_ty>))),
+            )
+            .collect()
+    }
+}
+
+pub fn make_type_annotations<D: TypeData>(mut data: D) -> Tokens {
+    data.annotate_return_type()
+        .into_iter()
+        .map(make_expr_with_type)
+        .map(|expr| quote!(return #expr;))
+        .chain(
+            data.annotate_yield_type()
+                .into_iter()
+                .map(make_expr_with_type)
+                .map(|expr| quote!(yield #expr;)),
+        )
+        .fold(Tokens::new(), |mut t, stmt| {
+            stmt.to_tokens(&mut t);
+            t
+        })
+}
+
+/// Returned expression will panic or abort if executed.
+///
+///```rust,ignore
+/// {
+///     let _v: Type = ::std::process::abort();
+///     _v
+/// }
+///```
+///
+fn make_expr_with_type(ty: Type) -> Tokens {
+    // use abort instead of unreachable because unreachable!()
+    //   make reading cargo-expanded code too hard.
+    quote_cs!({
+        let _v: #ty = ::futures::__rt::std::process::abort();
+        _v
+    })
+}

--- a/futures-await-async-macro/src/type_ann.rs
+++ b/futures-await-async-macro/src/type_ann.rs
@@ -1,5 +1,6 @@
 //! Creates type annotations for yield and return.
 use syn::*;
+use super::{first_last, respan};
 use quote::{ToTokens, Tokens};
 use std::iter;
 
@@ -102,8 +103,12 @@ pub fn make_type_annotations<D: TypeData>(mut data: D) -> Tokens {
 fn make_expr_with_type(ty: Type) -> Tokens {
     // use abort instead of unreachable because unreachable!()
     //   make reading cargo-expanded code too hard.
+    let sp = first_last(&ty);
+    let val = respan(quote!(_v).into(), &sp);
+    let abort_expr = respan(quote!(::futures::__rt::std::process::abort()).into(), &sp);
+
     quote_cs!({
-        let _v: #ty = ::futures::__rt::std::process::abort();
-        _v
+        let #val: #ty = #abort_expr;
+        #val
     })
 }

--- a/testcrate/ui/bad-return-type.stderr
+++ b/testcrate/ui/bad-return-type.stderr
@@ -23,6 +23,58 @@ error[E0308]: mismatched types
               found type `{integer}`
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
+error[E0907]: type inside generator must be known in this context
+  --> $DIR/bad-return-type.rs:19:9
+   |
+19 |     let val = Some(42);
+   |         ^^^
+   |
+note: the type is part of the generator because of this `yield`
+  --> $DIR/bad-return-type.rs:25:5
+   |
+25 |     stream_yield!(val);
+   |     ^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error[E0907]: type inside generator must be known in this context
+  --> $DIR/bad-return-type.rs:24:9
+   |
+24 |     let val = val.unwrap();
+   |         ^^^
+   |
+note: the type is part of the generator because of this `yield`
+  --> $DIR/bad-return-type.rs:25:5
+   |
+25 |     stream_yield!(val);
+   |     ^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error[E0907]: type inside generator must be known in this context
+  --> $DIR/bad-return-type.rs:25:5
+   |
+25 |     stream_yield!(val);
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+note: the type is part of the generator because of this `yield`
+  --> $DIR/bad-return-type.rs:25:5
+   |
+25 |     stream_yield!(val);
+   |     ^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error[E0907]: type inside generator must be known in this context
+  --> $DIR/bad-return-type.rs:25:5
+   |
+25 |     stream_yield!(val);
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+note: the type is part of the generator because of this `yield`
+  --> $DIR/bad-return-type.rs:25:5
+   |
+25 |     stream_yield!(val);
+   |     ^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
 error[E0308]: mismatched types
   --> $DIR/bad-return-type.rs:32:19
    |
@@ -32,5 +84,5 @@ error[E0308]: mismatched types
    = note: expected type `(i32, i32)`
               found type `{integer}`
 
-error: aborting due to 3 previous errors
+error: aborting due to 7 previous errors
 

--- a/testcrate/ui/bad-return-type.stderr
+++ b/testcrate/ui/bad-return-type.stderr
@@ -19,60 +19,8 @@ error[E0308]: mismatched types
    |     expected enum `std::option::Option`, found integral variable
    |     help: try using a variant of the expected type: `Some(e)`
    |
-   = note: expected type `std::option::Option<_>`
+   = note: expected type `std::option::Option<i32>`
               found type `{integer}`
-   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
-
-error[E0907]: type inside generator must be known in this context
-  --> $DIR/bad-return-type.rs:19:9
-   |
-19 |     let val = Some(42);
-   |         ^^^
-   |
-note: the type is part of the generator because of this `yield`
-  --> $DIR/bad-return-type.rs:25:5
-   |
-25 |     stream_yield!(val);
-   |     ^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
-
-error[E0907]: type inside generator must be known in this context
-  --> $DIR/bad-return-type.rs:24:9
-   |
-24 |     let val = val.unwrap();
-   |         ^^^
-   |
-note: the type is part of the generator because of this `yield`
-  --> $DIR/bad-return-type.rs:25:5
-   |
-25 |     stream_yield!(val);
-   |     ^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
-
-error[E0907]: type inside generator must be known in this context
-  --> $DIR/bad-return-type.rs:25:5
-   |
-25 |     stream_yield!(val);
-   |     ^^^^^^^^^^^^^^^^^^^
-   |
-note: the type is part of the generator because of this `yield`
-  --> $DIR/bad-return-type.rs:25:5
-   |
-25 |     stream_yield!(val);
-   |     ^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
-
-error[E0907]: type inside generator must be known in this context
-  --> $DIR/bad-return-type.rs:25:5
-   |
-25 |     stream_yield!(val);
-   |     ^^^^^^^^^^^^^^^^^^^
-   |
-note: the type is part of the generator because of this `yield`
-  --> $DIR/bad-return-type.rs:25:5
-   |
-25 |     stream_yield!(val);
-   |     ^^^^^^^^^^^^^^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error[E0308]: mismatched types
@@ -84,5 +32,5 @@ error[E0308]: mismatched types
    = note: expected type `(i32, i32)`
               found type `{integer}`
 
-error: aborting due to 7 previous errors
+error: aborting due to 3 previous errors
 

--- a/testcrate/ui/borrowed-argument.stderr
+++ b/testcrate/ui/borrowed-argument.stderr
@@ -1,24 +1,18 @@
-error[E0597]: `a` does not live long enough
+error[E0626]: borrow may still be in use when generator yields
   --> $DIR/borrowed-argument.rs:14:17
    |
 14 |     await!(bar(&a))?;
-   |                 ^ borrowed value does not live long enough
-...
-17 | }
-   | - borrowed value only lives until here
+   |     ------------^-- possible yield occurs here
    |
-   = note: borrowed value must be valid for the static lifetime...
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
-error[E0597]: `a` does not live long enough
+error[E0626]: borrow may still be in use when generator yields
   --> $DIR/borrowed-argument.rs:21:17
    |
 21 |     await!(bar(&a))?;
-   |                 ^ borrowed value does not live long enough
-...
-25 | }
-   | - borrowed value only lives until here
+   |     ------------^-- possible yield occurs here
    |
-   = note: borrowed value must be valid for the static lifetime...
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/testcrate/ui/borrowed-argument.stderr
+++ b/testcrate/ui/borrowed-argument.stderr
@@ -1,18 +1,24 @@
-error[E0626]: borrow may still be in use when generator yields
+error[E0597]: `a` does not live long enough
   --> $DIR/borrowed-argument.rs:14:17
    |
 14 |     await!(bar(&a))?;
-   |     ------------^-- possible yield occurs here
+   |                 ^ borrowed value does not live long enough
+...
+17 | }
+   | - borrowed value only lives until here
    |
-   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+   = note: borrowed value must be valid for the static lifetime...
 
-error[E0626]: borrow may still be in use when generator yields
+error[E0597]: `a` does not live long enough
   --> $DIR/borrowed-argument.rs:21:17
    |
 21 |     await!(bar(&a))?;
-   |     ------------^-- possible yield occurs here
+   |                 ^ borrowed value does not live long enough
+...
+25 | }
+   | - borrowed value only lives until here
    |
-   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+   = note: borrowed value must be valid for the static lifetime...
 
 error: aborting due to 2 previous errors
 

--- a/testcrate/ui/generic-not-static.stderr
+++ b/testcrate/ui/generic-not-static.stderr
@@ -6,7 +6,7 @@ error[E0310]: the parameter type `T` may not live long enough
   |        |
   |        help: consider adding an explicit lifetime bound `T: 'static`...
   |
-note: ...so that the type `impl futures::__rt::MyFuture<<[generator@$DIR/generic-not-static.rs:7:1: 10:2 t:T {std::result::Result<T, u32>, futures::Async<futures::__rt::Mu>, ()}] as std::ops::Generator>::Return>` will meet its required lifetime bounds
+note: ...so that the type `impl futures::__rt::MyFuture<<[generator@$DIR/generic-not-static.rs:7:1: 10:2 t:T (futures::Async<futures::__rt::Mu>, ())] as std::ops::Generator>::Return>` will meet its required lifetime bounds
  --> $DIR/generic-not-static.rs:8:20
   |
 8 | fn foo<T>(t: T) -> Result<T, u32> {
@@ -20,7 +20,7 @@ error[E0310]: the parameter type `T` may not live long enough
    |         |
    |         help: consider adding an explicit lifetime bound `T: 'static`...
    |
-note: ...so that the type `impl futures::__rt::MyStream<T, <[generator@$DIR/generic-not-static.rs:12:1: 16:2 t:T {T, fn(T) -> futures::Async<T> {futures::Async<T>::Ready}, futures::Async<T>, (), std::result::Result<(), u32>}] as std::ops::Generator>::Return>` will meet its required lifetime bounds
+note: ...so that the type `impl futures::__rt::MyStream<T, <[generator@$DIR/generic-not-static.rs:12:1: 16:2 t:T (futures::Async<T>, (), T, fn(T) -> futures::Async<T> {futures::Async<T>::Ready})] as std::ops::Generator>::Return>` will meet its required lifetime bounds
   --> $DIR/generic-not-static.rs:13:21
    |
 13 | fn foos<T>(t: T) -> Result<(), u32> {

--- a/testcrate/ui/generic-not-static.stderr
+++ b/testcrate/ui/generic-not-static.stderr
@@ -6,7 +6,7 @@ error[E0310]: the parameter type `T` may not live long enough
   |        |
   |        help: consider adding an explicit lifetime bound `T: 'static`...
   |
-note: ...so that the type `impl futures::__rt::MyFuture<<[generator@$DIR/generic-not-static.rs:7:1: 10:2 t:T (futures::Async<futures::__rt::Mu>, ())] as std::ops::Generator>::Return>` will meet its required lifetime bounds
+note: ...so that the type `impl futures::__rt::MyFuture<<[generator@$DIR/generic-not-static.rs:7:1: 10:2 t:T {futures::Async<futures::__rt::Mu>, ()}] as std::ops::Generator>::Return>` will meet its required lifetime bounds
  --> $DIR/generic-not-static.rs:8:20
   |
 8 | fn foo<T>(t: T) -> Result<T, u32> {
@@ -20,7 +20,7 @@ error[E0310]: the parameter type `T` may not live long enough
    |         |
    |         help: consider adding an explicit lifetime bound `T: 'static`...
    |
-note: ...so that the type `impl futures::__rt::MyStream<T, <[generator@$DIR/generic-not-static.rs:12:1: 16:2 t:T (futures::Async<T>, (), T, fn(T) -> futures::Async<T> {futures::Async<T>::Ready})] as std::ops::Generator>::Return>` will meet its required lifetime bounds
+note: ...so that the type `impl futures::__rt::MyStream<T, <[generator@$DIR/generic-not-static.rs:12:1: 16:2 t:T {futures::Async<T>, (), T, fn(T) -> futures::Async<T> {futures::Async<T>::Ready}}] as std::ops::Generator>::Return>` will meet its required lifetime bounds
   --> $DIR/generic-not-static.rs:13:21
    |
 13 | fn foos<T>(t: T) -> Result<(), u32> {

--- a/testcrate/ui/missing-item.stderr
+++ b/testcrate/ui/missing-item.stderr
@@ -1,3 +1,5 @@
+thread 'rustc' panicked at '#[async_stream] requires item type to be specified', libcore/option.rs:917:5
+note: Run with `RUST_BACKTRACE=1` for a backtrace.
 error: custom attribute panicked
  --> $DIR/missing-item.rs:8:1
   |

--- a/testcrate/ui/not-a-result.stderr
+++ b/testcrate/ui/not-a-result.stderr
@@ -1,8 +1,8 @@
 error[E0308]: mismatched types
- --> $DIR/not-a-result.rs:7:1
+ --> $DIR/not-a-result.rs:8:13
   |
-7 | #[async]
-  | ^^^^^^^^ expected enum `std::result::Result`, found u32
+8 | fn foo() -> u32 {
+  |             ^^^ expected enum `std::result::Result`, found u32
   |
   = note: expected type `std::result::Result<_, _>`
              found type `u32`
@@ -38,10 +38,10 @@ error[E0277]: the trait bound `u32: futures::__rt::IsResult` is not satisfied
    = help: the trait `futures::__rt::IsResult` is not implemented for `u32`
 
 error[E0308]: mismatched types
-  --> $DIR/not-a-result.rs:12:1
+  --> $DIR/not-a-result.rs:13:13
    |
-12 | #[async(boxed)]
-   | ^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found u32
+13 | fn bar() -> u32 {
+   |             ^^^ expected enum `std::result::Result`, found u32
    |
    = note: expected type `std::result::Result<_, _>`
               found type `u32`
@@ -64,10 +64,10 @@ error[E0308]: mismatched types
               found type `{integer}`
 
 error[E0308]: mismatched types
-  --> $DIR/not-a-result.rs:17:1
+  --> $DIR/not-a-result.rs:18:14
    |
-17 | #[async_stream(item = u32)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found u32
+18 | fn foos() -> u32 {
+   |              ^^^ expected enum `std::result::Result`, found u32
    |
    = note: expected type `std::result::Result<(), _>`
               found type `u32`
@@ -103,10 +103,10 @@ error[E0277]: the trait bound `u32: futures::__rt::IsResult` is not satisfied
    = help: the trait `futures::__rt::IsResult` is not implemented for `u32`
 
 error[E0308]: mismatched types
-  --> $DIR/not-a-result.rs:22:1
+  --> $DIR/not-a-result.rs:23:14
    |
-22 | #[async_stream(boxed, item = u32)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found u32
+23 | fn bars() -> u32 {
+   |              ^^^ expected enum `std::result::Result`, found u32
    |
    = note: expected type `std::result::Result<(), _>`
               found type `u32`

--- a/testcrate/ui/not-a-result.stderr
+++ b/testcrate/ui/not-a-result.stderr
@@ -1,3 +1,21 @@
+error[E0308]: mismatched types
+ --> $DIR/not-a-result.rs:7:1
+  |
+7 | #[async]
+  | ^^^^^^^^ expected enum `std::result::Result`, found u32
+  |
+  = note: expected type `std::result::Result<_, _>`
+             found type `u32`
+
+error[E0308]: mismatched types
+ --> $DIR/not-a-result.rs:9:5
+  |
+9 |     3
+  |     ^ expected enum `std::result::Result`, found integral variable
+  |
+  = note: expected type `std::result::Result<_, _>`
+             found type `{integer}`
+
 error[E0277]: the trait bound `u32: futures::__rt::IsResult` is not satisfied
  --> $DIR/not-a-result.rs:8:13
   |
@@ -5,7 +23,8 @@ error[E0277]: the trait bound `u32: futures::__rt::IsResult` is not satisfied
   |             ^^^ async functions must return a `Result` or a typedef of `Result`
   |
   = help: the trait `futures::__rt::IsResult` is not implemented for `u32`
-  = note: required by `futures::__rt::gen`
+  = note: required because of the requirements on the impl of `futures::__rt::MyFuture<u32>` for `impl futures::__rt::MyFuture<<[generator@$DIR/not-a-result.rs:7:1: 10:2 _] as std::ops::Generator>::Return>`
+  = note: the return type of a function must have a statically known size
 
 error[E0277]: the trait bound `u32: futures::__rt::IsResult` is not satisfied
   --> $DIR/not-a-result.rs:13:17
@@ -18,6 +37,15 @@ error[E0277]: the trait bound `u32: futures::__rt::IsResult` is not satisfied
    |
    = help: the trait `futures::__rt::IsResult` is not implemented for `u32`
 
+error[E0308]: mismatched types
+  --> $DIR/not-a-result.rs:12:1
+   |
+12 | #[async(boxed)]
+   | ^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found u32
+   |
+   = note: expected type `std::result::Result<_, _>`
+              found type `u32`
+
 error[E0277]: the trait bound `u32: futures::__rt::IsResult` is not satisfied
   --> $DIR/not-a-result.rs:13:13
    |
@@ -25,7 +53,33 @@ error[E0277]: the trait bound `u32: futures::__rt::IsResult` is not satisfied
    |             ^^^ async functions must return a `Result` or a typedef of `Result`
    |
    = help: the trait `futures::__rt::IsResult` is not implemented for `u32`
-   = note: required by `futures::__rt::gen`
+
+error[E0308]: mismatched types
+  --> $DIR/not-a-result.rs:14:5
+   |
+14 |     3
+   |     ^ expected enum `std::result::Result`, found integral variable
+   |
+   = note: expected type `std::result::Result<_, _>`
+              found type `{integer}`
+
+error[E0308]: mismatched types
+  --> $DIR/not-a-result.rs:17:1
+   |
+17 | #[async_stream(item = u32)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found u32
+   |
+   = note: expected type `std::result::Result<(), _>`
+              found type `u32`
+
+error[E0308]: mismatched types
+  --> $DIR/not-a-result.rs:19:5
+   |
+19 |     3
+   |     ^ expected enum `std::result::Result`, found integral variable
+   |
+   = note: expected type `std::result::Result<(), _>`
+              found type `{integer}`
 
 error[E0277]: the trait bound `u32: futures::__rt::IsResult` is not satisfied
   --> $DIR/not-a-result.rs:18:14
@@ -34,7 +88,8 @@ error[E0277]: the trait bound `u32: futures::__rt::IsResult` is not satisfied
    |              ^^^ async functions must return a `Result` or a typedef of `Result`
    |
    = help: the trait `futures::__rt::IsResult` is not implemented for `u32`
-   = note: required by `futures::__rt::gen_stream`
+   = note: required because of the requirements on the impl of `futures::__rt::MyStream<u32, u32>` for `impl futures::__rt::MyStream<u32, <[generator@$DIR/not-a-result.rs:17:1: 20:2 _] as std::ops::Generator>::Return>`
+   = note: the return type of a function must have a statically known size
 
 error[E0277]: the trait bound `u32: futures::__rt::IsResult` is not satisfied
   --> $DIR/not-a-result.rs:23:18
@@ -47,6 +102,15 @@ error[E0277]: the trait bound `u32: futures::__rt::IsResult` is not satisfied
    |
    = help: the trait `futures::__rt::IsResult` is not implemented for `u32`
 
+error[E0308]: mismatched types
+  --> $DIR/not-a-result.rs:22:1
+   |
+22 | #[async_stream(boxed, item = u32)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found u32
+   |
+   = note: expected type `std::result::Result<(), _>`
+              found type `u32`
+
 error[E0277]: the trait bound `u32: futures::__rt::IsResult` is not satisfied
   --> $DIR/not-a-result.rs:23:14
    |
@@ -54,7 +118,15 @@ error[E0277]: the trait bound `u32: futures::__rt::IsResult` is not satisfied
    |              ^^^ async functions must return a `Result` or a typedef of `Result`
    |
    = help: the trait `futures::__rt::IsResult` is not implemented for `u32`
-   = note: required by `futures::__rt::gen_stream`
 
-error: aborting due to 6 previous errors
+error[E0308]: mismatched types
+  --> $DIR/not-a-result.rs:24:5
+   |
+24 |     3
+   |     ^ expected enum `std::result::Result`, found integral variable
+   |
+   = note: expected type `std::result::Result<(), _>`
+              found type `{integer}`
+
+error: aborting due to 14 previous errors
 

--- a/testcrate/ui/unresolved-type.stderr
+++ b/testcrate/ui/unresolved-type.stderr
@@ -14,17 +14,5 @@ error[E0412]: cannot find type `A` in this scope
    |
    = help: there is an enum variant `futures::future::Either::A`, try using `futures::future::Either`?
 
-error[E0907]: type inside generator must be known in this context
-  --> $DIR/unresolved-type.rs:12:1
-   |
-12 | #[async_stream(item = A)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: the type is part of the generator because of this `yield`
-  --> $DIR/unresolved-type.rs:12:1
-   |
-12 | #[async_stream(item = A)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Added type annotations without proper respanning. 

TODOs
 - [x] Respanning

 - [x] Type annotation for async_block and async_stream_block
 - [x] Tests
 - [ ] (maybe) Remove ::__rt::Mu as it can be replaced with `YieldType::not_ready()` (which is similar to `Default::default()`)


Is using `procmacro2_unstable` acceptable?

-----
Edit: Added question about `procmacro2_unstable` (I forgot why I created this pr..)
