### PR TITLE
Make boxed generators compatible with futures-cpupool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,6 @@ futures-await-await-macro = { path = "futures-await-await-macro", version = "0.1
 futures = "0.1"
 
 [dev-dependencies]
+futures-cpupool = "0.1"
 tokio-core = "0.1"
 tokio-io = "0.1"

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -6,10 +6,12 @@
 #![feature(proc_macro, conservative_impl_trait, generators)]
 
 extern crate futures_await as futures;
+extern crate futures_cpupool;
 
 use std::io;
 
 use futures::prelude::*;
+use futures_cpupool::CpuPool;
 
 #[async]
 fn foo() -> Result<i32, i32> {
@@ -56,6 +58,11 @@ fn _foo7<T>(t: T) -> Result<T, i32>
 #[async(boxed)]
 fn _foo8(a: i32, b: i32) -> Result<i32, i32> {
     return Ok(a + b)
+}
+
+#[async(boxed_send)]
+fn _foo9() -> Result<(), ()> {
+    Ok(())
 }
 
 #[async]
@@ -233,4 +240,10 @@ fn poll_stream_after_error() {
     assert_eq!(s.poll(), Ok(Async::Ready(Some(5))));
     assert_eq!(s.poll(), Err(()));
     assert_eq!(s.poll(), Ok(Async::Ready(None)));
+}
+
+#[test]
+fn run_boxed_future_in_cpu_pool() {
+    let pool = CpuPool::new_num_cpus();
+    pool.spawn(_foo9()).wait().unwrap();
 }


### PR DESCRIPTION
Fixes #60.

This change basically adds a new attribute `#[async(boxed_send)]` which makes boxed generators `Send` and able to be passed to `CpuPool.spawn()`.