### PR TITLE
Readme contribution guidelines: reference to Serde

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,5 +601,5 @@ at your option.
 ### Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in Serde by you, as defined in the Apache-2.0 license, shall be
+for inclusion in `futures-await` by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.


### PR DESCRIPTION
Currently the contribution guidelines at the bottom of README.md mention Serde, but I think they should instead refer to this crate.