### PR TITLE
Fix pinned boxed async functions

### DIFF
--- a/futures-await-async-macro/src/attribute.rs
+++ b/futures-await-async-macro/src/attribute.rs
@@ -1,0 +1,27 @@
+use self::Attribute::*;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Attribute {
+    Pinned,
+    PinnedBoxed,
+    PinnedBoxedSend,
+    Unpinned,
+    UnpinnedBoxed,
+    UnpinnedBoxedSend,
+}
+
+impl Attribute {
+    pub fn boxed(&self) -> bool {
+        match *self {
+            PinnedBoxed | PinnedBoxedSend | UnpinnedBoxed | UnpinnedBoxedSend => true,
+            Pinned | Unpinned => false,
+        }
+    }
+
+    pub fn pinned(&self) -> bool {
+        match *self {
+            Pinned | PinnedBoxed | PinnedBoxedSend => true,
+            Unpinned | UnpinnedBoxed | UnpinnedBoxedSend => false,
+        }
+    }
+}

--- a/futures-await-async-macro/src/lib.rs
+++ b/futures-await-async-macro/src/lib.rs
@@ -28,14 +28,16 @@ use syn::punctuated::Punctuated;
 use syn::fold::Fold;
 
 mod elision;
+mod attribute;
+
+use attribute::Attribute;
 
 macro_rules! quote_cs {
     ($($t:tt)*) => (quote_spanned!(Span::call_site() => $($t)*))
 }
 
 fn async_inner<F>(
-    boxed: bool,
-    pinned: bool,
+    attribute: Attribute,
     function: TokenStream,
     gen_function: Tokens,
     return_ty: F,
@@ -204,7 +206,7 @@ where F: FnOnce(&Type, &[&Lifetime]) -> proc_macro2::TokenStream
     // sure if more errors will highlight this function call...
     let output_span = first_last(&output);
     let gen_function = respan(gen_function.into(), &output_span);
-    let body_inner = if pinned {
+    let body_inner = if attribute.pinned() {
         quote_cs! {
             #gen_function (static move || -> #output #gen_body)
         }
@@ -213,14 +215,14 @@ where F: FnOnce(&Type, &[&Lifetime]) -> proc_macro2::TokenStream
             #gen_function (move || -> #output #gen_body)
         }
     };
-    let body_inner = if boxed {
-        let body = if pinned {
-            quote_cs! { (#body_inner).pin() } // TODO: Use pin_local if !send.
-        } else {
-            quote_cs! { ::futures::__rt::std::boxed::Box::new(#body_inner) }
-        };
-
-        respan(body.into(), &output_span)
+    let body_inner = match attribute {
+        Attribute::PinnedBoxed => quote_cs! { (#body_inner).pin_local() },
+        Attribute::PinnedBoxedSend => quote_cs! { (#body_inner).pin() },
+        Attribute::UnpinnedBoxed | Attribute::UnpinnedBoxedSend => quote_cs! { ::futures::__rt::std::boxed::Box::new(#body_inner) },
+        Attribute::Pinned | Attribute::Unpinned => body_inner,
+    };
+    let body_inner = if attribute.boxed() {
+        respan(body_inner.into(), &output_span)
     } else {
         body_inner.into()
     };
@@ -244,35 +246,34 @@ where F: FnOnce(&Type, &[&Lifetime]) -> proc_macro2::TokenStream
 
 #[proc_macro_attribute]
 pub fn async(attribute: TokenStream, function: TokenStream) -> TokenStream {
-    let (boxed, send) = match &attribute.to_string() as &str {
-        "( pinned )" => (true, false),
-        "( pinned_send )" => (true, true),
-        "" => (false, false),
+    let attribute = match &attribute.to_string() as &str {
+        "( pinned )" => Attribute::PinnedBoxed,
+        "( pinned_send )" => Attribute::PinnedBoxedSend,
+        "" => Attribute::Pinned,
         _ => panic!("the #[async] attribute currently only takes `pinned` `pinned_send` as an arg"),
     };
 
-    async_inner(boxed, true, function, quote_cs! { ::futures::__rt::gen_pinned }, |output, lifetimes| {
+    async_inner(attribute, function, quote_cs! { ::futures::__rt::gen_pinned }, |output, lifetimes| {
         // TODO: can we lift the restriction that `futures` must be at the root of
         //       the crate?
         let output_span = first_last(&output);
-        let return_ty = if boxed && !send {
-            quote_cs! {
+        let return_ty = match attribute {
+            Attribute::PinnedBoxed => quote_cs! {
                 ::futures::__rt::std::boxed::PinBox<::futures::__rt::Future<
                     Item = <! as ::futures::__rt::IsResult>::Ok,
                     Error = <! as ::futures::__rt::IsResult>::Err,
                 > + #(#lifetimes +)*>
-            }
-        } else if boxed && send {
-            quote_cs! {
+            },
+            Attribute::PinnedBoxedSend => quote_cs! {
                 ::futures::__rt::std::boxed::PinBox<::futures::__rt::Future<
                     Item = <! as ::futures::__rt::IsResult>::Ok,
                     Error = <! as ::futures::__rt::IsResult>::Err,
                 > + Send + #(#lifetimes +)*>
-            }
-        } else {
-            quote_cs! {
+            },
+            Attribute::Pinned => quote_cs! {
                 impl ::futures::__rt::MyStableFuture<!> + #(#lifetimes +)*
-            }
+            },
+            _ => unreachable!(),
         };
         let return_ty = respan(return_ty.into(), &output_span);
         replace_bang(return_ty, &output)
@@ -282,32 +283,30 @@ pub fn async(attribute: TokenStream, function: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn async_move(attribute: TokenStream, function: TokenStream) -> TokenStream {
     // Handle arguments to the #[async_move] attribute, if any
-    let (boxed, send) = match &attribute.to_string() as &str {
-        "( boxed )" => (true, false),
-        "( boxed_send )" => (true, true),
-        "" => (false, false),
+    let attribute = match &attribute.to_string() as &str {
+        "( boxed )" => Attribute::UnpinnedBoxed,
+        "( boxed_send )" => Attribute::UnpinnedBoxedSend,
+        "" => Attribute::Unpinned,
         _ => panic!("the #[async_move] attribute currently only takes `boxed` or `boxed_send`, as an arg"),
     };
 
-    async_inner(boxed, false, function, quote_cs! { ::futures::__rt::gen_move }, |output, lifetimes| {
+    async_inner(attribute, function, quote_cs! { ::futures::__rt::gen_move }, |output, lifetimes| {
         // TODO: can we lift the restriction that `futures` must be at the root of
         //       the crate?
         let output_span = first_last(&output);
-        let return_ty = if boxed && !send {
-            quote_cs! {
+        let return_ty = match attribute {
+            Attribute::UnpinnedBoxed => quote_cs! {
                 ::futures::__rt::std::boxed::Box<::futures::__rt::Future<
                     Item = <! as ::futures::__rt::IsResult>::Ok,
                     Error = <! as ::futures::__rt::IsResult>::Err,
                 > + ::futures::__rt::std::marker::Unpin + #(#lifetimes +)*>
-            }
-        } else if boxed && send {
-            quote_cs! {
+            },
+            Attribute::UnpinnedBoxedSend => quote_cs! {
                 ::futures::__rt::std::boxed::Box<::futures::__rt::Future<
                     Item = <! as ::futures::__rt::IsResult>::Ok,
                     Error = <! as ::futures::__rt::IsResult>::Err,
                 > + ::futures::__rt::std::marker::Unpin + Send + #(#lifetimes +)*>
-            }
-        } else {
+            },
             // Dunno why this is buggy, hits weird typecheck errors in tests
             //
             // quote_cs! {
@@ -316,7 +315,8 @@ pub fn async_move(attribute: TokenStream, function: TokenStream) -> TokenStream 
             //         Error = <#output as ::futures::__rt::MyTry>::MyError,
             //     >
             // }
-            quote_cs! { impl ::futures::__rt::MyFuture<!> + #(#lifetimes +)* }
+            Attribute::Unpinned => quote_cs! { impl ::futures::__rt::MyFuture<!> + #(#lifetimes +)* },
+            _ => unreachable!(),
         };
         let return_ty = respan(return_ty.into(), &output_span);
         replace_bang(return_ty, &output)
@@ -357,10 +357,10 @@ pub fn async_stream(attribute: TokenStream, function: TokenStream) -> TokenStrea
         }
     }
 
-    let boxed = boxed;
+    let attribute = if boxed { Attribute::PinnedBoxed } else { Attribute::Pinned };
     let item_ty = item_ty.expect("#[async_stream] requires item type to be specified");
 
-    async_inner(boxed, true, function, quote_cs! { ::futures::__rt::gen_stream_pinned }, |output, lifetimes| {
+    async_inner(attribute, function, quote_cs! { ::futures::__rt::gen_stream_pinned }, |output, lifetimes| {
         let output_span = first_last(&output);
         let return_ty = if boxed {
             quote_cs! {
@@ -411,10 +411,10 @@ pub fn async_stream_move(attribute: TokenStream, function: TokenStream) -> Token
         }
     }
 
-    let boxed = boxed;
+    let attribute = if boxed { Attribute::UnpinnedBoxed } else { Attribute::Unpinned };
     let item_ty = item_ty.expect("#[async_stream_move] requires item type to be specified");
 
-    async_inner(boxed, false, function, quote_cs! { ::futures::__rt::gen_stream }, |output, lifetimes| {
+    async_inner(attribute, function, quote_cs! { ::futures::__rt::gen_stream }, |output, lifetimes| {
         let output_span = first_last(&output);
         let return_ty = if boxed {
             quote_cs! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub use futures::*;
 
 pub mod prelude {
     pub use futures::prelude::*;
+    pub use stable::{StableFuture, StableStream};
     pub use async_macro::{async, async_move, async_stream, async_stream_move, async_block, async_stream_block};
     pub use await_macro::{await, stream_yield, await_item};
 }

--- a/tests/pinned.rs
+++ b/tests/pinned.rs
@@ -2,7 +2,8 @@
 
 extern crate futures_await as futures;
 
-use futures::stable::block_on_stable;
+use futures::stable::{block_on_stable, StableExecutor};
+use futures::executor::{block_on, ThreadPool};
 use futures::prelude::*;
 
 #[async]
@@ -18,6 +19,21 @@ fn bar(x: &i32) -> Result<i32, i32> {
 #[async]
 fn baz(x: i32) -> Result<i32, i32> {
     await!(bar(&x))
+}
+
+#[async(pinned)]
+fn boxed(x: i32) -> Result<i32, i32> {
+    Ok(x)
+}
+
+#[async(pinned_send)]
+fn boxed_send(x: i32) -> Result<i32, i32> {
+    Ok(x)
+}
+
+#[async(pinned_send)]
+fn spawnable() -> Result<(), Never> {
+    Ok(())
 }
 
 #[async_stream(item = u64)]
@@ -44,5 +60,13 @@ fn main() {
     assert_eq!(block_on_stable(foo()), Ok(1));
     assert_eq!(block_on_stable(bar(&1)), Ok(1));
     assert_eq!(block_on_stable(baz(17)), Ok(17));
+    assert_eq!(block_on(boxed(17)), Ok(17));
+    assert_eq!(block_on(boxed_send(17)), Ok(17));
     assert_eq!(block_on_stable(uses_async_for()), Ok(vec![0, 1]));
+}
+
+#[test]
+fn run_pinned_future_in_thread_pool() {
+    let mut pool = ThreadPool::new();
+    pool.spawn_pinned(spawnable()).unwrap();
 }


### PR DESCRIPTION
`#[async(pinned)]` and `#[async(pinned_send)` seem to be broken.

## My bad below

~~I could not run tests locally somehow.~~

```
> cargo test
    Updating registry `https://github.com/rust-lang/crates.io-index`
error: no matching package named `futures-await` found (required by `testcrate`)
location searched: file:///home/raviqqe/src/github.com/alexcrichton/futures-await
version required: = 0.1.0
```