### PR TITLE
Support building in `no_std` environments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,12 @@ members = ["testcrate"]
 [dependencies]
 futures-await-async-macro = { path = "futures-await-async-macro", version = "0.2.0-alpha" }
 futures-await-await-macro = { path = "futures-await-await-macro", version = "0.2.0-alpha" }
-futures = { git = "https://github.com/rust-lang-nursery/futures-rs.git", features = ["nightly"] }
+
+[dependencies.futures]
+git = "https://github.com/rust-lang-nursery/futures-rs.git"
+default-features = false
+features = ["nightly"]
+
+[features]
+std = ["futures/std"]
+default = ["std"]

--- a/futures-await-async-macro/src/lib.rs
+++ b/futures-await-async-macro/src/lib.rs
@@ -293,14 +293,14 @@ pub fn async_move(attribute: TokenStream, function: TokenStream) -> TokenStream 
                 ::futures::__rt::std::boxed::Box<::futures::__rt::Future<
                     Item = <! as ::futures::__rt::IsResult>::Ok,
                     Error = <! as ::futures::__rt::IsResult>::Err,
-                > + ::futures::__rt::std::marker::Unpin + #(#lifetimes +)*>
+                > + ::futures::__rt::core::marker::Unpin + #(#lifetimes +)*>
             }
         } else if boxed && send {
             quote_cs! {
                 ::futures::__rt::std::boxed::Box<::futures::__rt::Future<
                     Item = <! as ::futures::__rt::IsResult>::Ok,
                     Error = <! as ::futures::__rt::IsResult>::Err,
-                > + ::futures::__rt::std::marker::Unpin + Send + #(#lifetimes +)*>
+                > + ::futures::__rt::core::marker::Unpin + Send + #(#lifetimes +)*>
             }
         } else {
             // Dunno why this is buggy, hits weird typecheck errors in tests
@@ -416,7 +416,7 @@ pub fn async_stream_move(attribute: TokenStream, function: TokenStream) -> Token
                 ::futures::__rt::std::boxed::Box<::futures::__rt::Stream<
                     Item = !,
                     Error = <! as ::futures::__rt::IsResult>::Err,
-                > + ::futures::__rt::std::marker::Unpin + #(#lifetimes +)*>
+                > + ::futures::__rt::core::marker::Unpin + #(#lifetimes +)*>
             }
         } else {
             quote_cs! { impl ::futures::__rt::MyStream<!, !> + #(#lifetimes +)* }
@@ -523,15 +523,15 @@ impl Fold for ExpandAsyncFor {
                 let #pat = {
                     let r = {
                         let pin = unsafe {
-                            ::futures::__rt::std::mem::Pin::new_unchecked(&mut __stream)
+                            ::futures::__rt::core::mem::Pin::new_unchecked(&mut __stream)
                         };
                         ::futures::__rt::in_ctx(|ctx| ::futures::__rt::StableStream::poll_next(pin, ctx))
                     };
                     match r? {
                         ::futures::__rt::Async::Ready(e) => {
                             match e {
-                                ::futures::__rt::std::option::Option::Some(e) => e,
-                                ::futures::__rt::std::option::Option::None => break,
+                                ::futures::__rt::core::option::Option::Some(e) => e,
+                                ::futures::__rt::core::option::Option::None => break,
                             }
                         }
                         ::futures::__rt::Async::Pending => {

--- a/futures-await-await-macro/src/lib.rs
+++ b/futures-await-await-macro/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 /// Ye Olde Await Macro
 ///
 /// Basically a translation of polling to yielding. This crate's macro is
@@ -15,19 +17,19 @@ macro_rules! await {
         loop {
             let poll = {
                 let pin = unsafe {
-                    ::futures::__rt::std::mem::Pin::new_unchecked(&mut future)
+                    ::futures::__rt::core::mem::Pin::new_unchecked(&mut future)
                 };
                 ::futures::__rt::in_ctx(|ctx| ::futures::__rt::StableFuture::poll(pin, ctx))
             };
             // Allow for #[feature(never_type)] and Future<Error = !>
             #[allow(unreachable_code, unreachable_patterns)]
             match poll {
-                ::futures::__rt::std::result::Result::Ok(::futures::__rt::Async::Ready(e)) => {
-                    break ::futures::__rt::std::result::Result::Ok(e)
+                ::futures::__rt::core::result::Result::Ok(::futures::__rt::Async::Ready(e)) => {
+                    break ::futures::__rt::core::result::Result::Ok(e)
                 }
-                ::futures::__rt::std::result::Result::Ok(::futures::__rt::Async::Pending) => {}
-                ::futures::__rt::std::result::Result::Err(e) => {
-                    break ::futures::__rt::std::result::Result::Err(e)
+                ::futures::__rt::core::result::Result::Ok(::futures::__rt::Async::Pending) => {}
+                ::futures::__rt::core::result::Result::Err(e) => {
+                    break ::futures::__rt::core::result::Result::Err(e)
                 }
             }
             yield ::futures::__rt::Async::Pending
@@ -48,12 +50,12 @@ macro_rules! await_item {
             // Allow for #[feature(never_type)] and Stream<Error = !>
             #[allow(unreachable_code, unreachable_patterns)]
             match poll {
-                ::futures::__rt::std::result::Result::Ok(::futures::__rt::Async::Ready(e)) => {
-                    break ::futures::__rt::std::result::Result::Ok(e)
+                ::futures::__rt::core::result::Result::Ok(::futures::__rt::Async::Ready(e)) => {
+                    break ::futures::__rt::core::result::Result::Ok(e)
                 }
-                ::futures::__rt::std::result::Result::Ok(::futures::__rt::Async::Pending) => {}
-                ::futures::__rt::std::result::Result::Err(e) => {
-                    break ::futures::__rt::std::result::Result::Err(e)
+                ::futures::__rt::core::result::Result::Ok(::futures::__rt::Async::Pending) => {}
+                ::futures::__rt::core::result::Result::Err(e) => {
+                    break ::futures::__rt::core::result::Result::Err(e)
                 }
             }
 

--- a/src/__rt/future.rs
+++ b/src/__rt/future.rs
@@ -1,4 +1,4 @@
-use std::ops::{Generator, GeneratorState};
+use core::ops::{Generator, GeneratorState};
 
 use super::{IsResult, Reset, CTX};
 

--- a/src/__rt/mod.rs
+++ b/src/__rt/mod.rs
@@ -2,9 +2,10 @@ mod future;
 mod stream;
 mod pinned_future; mod pinned_stream;
 
-use std::cell::Cell;
-use std::mem;
-use std::ptr;
+use core::cell::Cell;
+use core::mem;
+use core::ptr;
+use core::result::Result;
 use futures::task;
 
 pub use self::future::*;
@@ -15,9 +16,11 @@ pub use self::pinned_stream::*;
 pub use futures::prelude::{Async, Future, Stream};
 pub use futures::stable::{StableFuture, StableStream};
 
+pub extern crate core;
+#[cfg(feature = "std")]
 pub extern crate std;
 
-pub use std::ops::Generator;
+pub use core::ops::Generator;
 
 #[rustc_on_unimplemented = "async functions must return a `Result` or \
                             a typedef of `Result`"]
@@ -38,6 +41,7 @@ pub fn diverge<T>() -> T { loop {} }
 
 type StaticContext = *mut task::Context<'static>;
 
+#[cfg(feature = "std")]
 thread_local!(static CTX: Cell<StaticContext> = Cell::new(ptr::null_mut()));
 
 struct Reset<'a>(StaticContext, &'a Cell<StaticContext>);

--- a/src/__rt/pinned_future.rs
+++ b/src/__rt/pinned_future.rs
@@ -1,6 +1,6 @@
-use std::marker::Unpin;
-use std::mem::Pin;
-use std::ops::{Generator, GeneratorState};
+use core::marker::Unpin;
+use core::mem::Pin;
+use core::ops::{Generator, GeneratorState};
 
 use super::{IsResult, Reset, CTX};
 

--- a/src/__rt/pinned_stream.rs
+++ b/src/__rt/pinned_stream.rs
@@ -1,6 +1,6 @@
-use std::mem::Pin;
-use std::ops::{Generator, GeneratorState};
-use std::marker::{PhantomData, Unpin};
+use core::mem::Pin;
+use core::ops::{Generator, GeneratorState};
+use core::marker::{PhantomData, Unpin};
 
 use futures::task;
 use futures::prelude::{Poll, Async};

--- a/src/__rt/stream.rs
+++ b/src/__rt/stream.rs
@@ -1,5 +1,5 @@
-use std::ops::{Generator, GeneratorState};
-use std::marker::PhantomData;
+use core::ops::{Generator, GeneratorState};
+use core::marker::PhantomData;
 
 use futures::task;
 use futures::prelude::{Poll, Async, Stream};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@
 //!
 //! See the crates's README for more information about usage.
 
+#![no_std]
+
 #![feature(conservative_impl_trait)]
 #![feature(generator_trait)]
 #![feature(use_extern_macros)]
@@ -19,6 +21,10 @@
 #![feature(arbitrary_self_types)]
 #![feature(optin_builtin_traits)]
 #![feature(pin)]
+
+#[cfg(feature = "std")]
+#[macro_use]
+extern crate std;
 
 extern crate futures_await_async_macro as async_macro;
 extern crate futures_await_await_macro as await_macro;

--- a/testcrate/ui/unresolved-type.stderr
+++ b/testcrate/ui/unresolved-type.stderr
@@ -4,6 +4,7 @@ error[E0412]: cannot find type `Left` in this scope
 8 | fn foo() -> Result<Left, u32> {
   |                    ^^^^ not found in this scope
   |
+  = help: there is an enum variant `futures::__rt::core::fmt::Alignment::Left`, try using `futures::__rt::core::fmt::Alignment`?
   = help: there is an enum variant `futures::future::Either::Left`, try using `futures::future::Either`?
   = help: there is an enum variant `std::fmt::rt::v1::Alignment::Left`, try using `std::fmt::rt::v1::Alignment`?
 
@@ -13,6 +14,7 @@ error[E0412]: cannot find type `Left` in this scope
 12 | #[async_stream(item = Left)]
    |                       ^^^^ not found in this scope
    |
+   = help: there is an enum variant `futures::__rt::core::fmt::Alignment::Left`, try using `futures::__rt::core::fmt::Alignment`?
    = help: there is an enum variant `futures::future::Either::Left`, try using `futures::future::Either`?
    = help: there is an enum variant `std::fmt::rt::v1::Alignment::Left`, try using `std::fmt::rt::v1::Alignment`?
 


### PR DESCRIPTION
This doesn't actually build on targets that don't provide a `std` crate because of some missing changes in `futures 0.2.0-alpha`, but it does successfully build a `no_std` version of the `futures-await` crate on targets that provide a `std` crate.

This branch + https://github.com/rust-lang-nursery/futures-rs/pull/845 + a custom executor is capable of running self-referential `#[async]` futures on alloc-less bare-metal devices :tada:

I'm really not sure what to do about the context storage, as far as I'm aware this is safe on single-threaded devices, but I'm not sure if this might ever be used on a non-single-threaded device.