### PR TITLE
Fix nightly breakage from proc-macro

### DIFF
--- a/futures-await-async-macro/Cargo.toml
+++ b/futures-await-async-macro/Cargo.toml
@@ -13,10 +13,10 @@ few other assorted macros.
 proc-macro = true
 
 [dependencies]
-quote = "0.4"
-proc-macro2 = { version = "0.2", features = ["nightly"] }
+quote = "0.5"
+proc-macro2 = { version = "0.3", features = ["nightly"] }
 
 [dependencies.syn]
-version = "0.12.13"
-features = ["full", "fold", "parsing", "printing", "extra-traits"]
+version = "0.13"
+features = ["full", "fold", "parsing", "printing", "extra-traits", "proc-macro"]
 default-features = false

--- a/futures-await-async-macro/src/elision.rs
+++ b/futures-await-async-macro/src/elision.rs
@@ -1,4 +1,4 @@
-use proc_macro2::{Term, Span};
+use proc_macro2::Span;
 use syn::*;
 use syn::punctuated::Punctuated;
 use syn::token::Comma;
@@ -34,7 +34,7 @@ impl<'a> UnelideLifetimes<'a> {
     // Constitute a new lifetime
     fn new_lifetime(&mut self) -> Lifetime {
         let lifetime_name = format!("{}{}", self.lifetime_name, self.count);
-        let lifetime = Lifetime::new(Term::intern(&lifetime_name), Span::call_site());
+        let lifetime = Lifetime::new(&lifetime_name, Span::call_site());
 
         let idx = self.lifetime_index + self.count as usize;
         self.generics.insert(idx, GenericParam::Lifetime(LifetimeDef::new(lifetime.clone())));

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -235,6 +235,6 @@ fn poll_stream_after_error() {
 
 #[test]
 fn run_boxed_future_in_cpu_pool() {
-    let mut pool = executor::ThreadPool::new();
+    let mut pool = executor::ThreadPool::new().unwrap();
     pool.spawn(_foo9()).unwrap();
 }


### PR DESCRIPTION
This is supposed to fix #87, I'm not entirely sure if these are all of the necessary changes! `cargo test` and `cargo clean; cd testcrate; cargo test` succeed, but besides that I'm not sure what to test. It just updates `proc-macro2` usage from 0.2 to 0.3. Also, is `futures-await` even the correct place to be going for `#[async]` and `await!()`? I see that `futures-rs` now contains the macro crates, but I can't find a version (0.2.0, 0.2.0-alpha, 0.2.0-beta don't seem to work, and 0.1.21 doesn't seem to have it, and I can't find a git revision that works either). Also, I noticed that the not found error is currently breaking Travis for `futures-rs`) for that works (I always get `#[async]` not found, and I am using `features = ["nightly"]`).

Edit: Oh, also, `tests/smoke.rs` usage of `ThreadPool` needs to be updated to have `unwrap()` in order for `cargo test` to work, I have another branch in my fork that makes this change, but I didn't include it in this PR.

Edit2: Actually, just to make Travis succeed, I added the `tests/smoke.rs` update! Not sure if this is desired.