### PR TITLE
fix build and test issues due to new nightly

### DIFF
--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -2,7 +2,7 @@
 //!
 //! Very similar to the example at https://tokio.rs
 
-#![feature(proc_macro, generators)]
+#![feature(proc_macro, proc_macro_non_items, generators)]
 
 extern crate futures_await as futures;
 extern crate tokio_core;

--- a/futures-await-async-macro/src/lib.rs
+++ b/futures-await-async-macro/src/lib.rs
@@ -231,8 +231,8 @@ where
 pub fn async(attribute: TokenStream, function: TokenStream) -> TokenStream {
 	// Handle arguments to the #[async] attribute, if any
 	let (boxed, send) = match &attribute.to_string() as &str {
-		"( boxed )" => (true, false),
-		"( boxed_send )" => (true, true),
+		"boxed" => (true, false),
+		"boxed_send" => (true, true),
 		"" => (false, false),
 		_ => panic!("the #[async] attribute currently only takes `boxed` as an arg"),
 	};

--- a/futures-await-async-macro/src/lib.rs
+++ b/futures-await-async-macro/src/lib.rs
@@ -9,7 +9,6 @@
 //! Currently this crate depends on `syn` and `quote` to do all the heavy
 //! lifting, this is just a very small shim around creating a closure/future out
 //! of a generator.
-
 #![feature(proc_macro)]
 #![recursion_limit = "128"]
 
@@ -536,7 +535,7 @@ struct AsyncStreamArgs(Vec<AsyncStreamArg>);
 
 impl synom::Synom for AsyncStreamArgs {
 	named!(parse -> Self, map!(
-        option!(parens!(call!(Punctuated::<AsyncStreamArg, syn::token::Comma>::parse_separated_nonempty))),
-        |p| AsyncStreamArgs(p.map(|d| d.1.into_iter().collect()).unwrap_or_default())
+        option!(call!(Punctuated::<AsyncStreamArg, syn::token::Comma>::parse_separated_nonempty)),
+        |p| AsyncStreamArgs(p.map(|d| d.into_iter().collect()).unwrap_or_default())
     ));
 }

--- a/testcrate/ui/move-captured-variable.rs
+++ b/testcrate/ui/move-captured-variable.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro, generators)]
+#![feature(proc_macro, proc_macro_non_items, generators)]
 
 extern crate futures_await as futures;
 

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -3,7 +3,7 @@
 //! This is mostly a test for this repository itself, not necessarily serving
 //! much more purpose than that.
 
-#![feature(proc_macro, generators)]
+#![feature(proc_macro, proc_macro_non_items, generators)]
 
 extern crate futures_await as futures;
 extern crate futures_cpupool;


### PR DESCRIPTION
This pull request contains patches required to make 'cargo test' build and pass again.

As described in pull request #97, parens in attribute macros are no longer included in the token stream. async and async_stream macro code needs to be changed accordingly.

This pull request contains both the commit from pull request #97 (which fixes this for the async macro), as well as a fix for the same issue in the async_stream macro. 

Additionally, three files now have the proc_macro_non_items feature enabled as this was required to run the tests.