### PR TITLE
Update quote & syn

### DIFF
--- a/futures-await-async-macro/Cargo.toml
+++ b/futures-await-async-macro/Cargo.toml
@@ -13,10 +13,10 @@ few other assorted macros.
 proc-macro = true
 
 [dependencies]
-quote = "0.5"
-proc-macro2 = { version = "0.3", features = ["nightly"] }
+quote = "0.6"
+proc-macro2 = { version = "0.4", features = ["nightly"] }
 
 [dependencies.syn]
-version = "0.13.1"
+version = "0.14"
 features = ["full", "fold", "parsing", "printing", "proc-macro"]
 default-features = false


### PR DESCRIPTION
Hi, I naively tried to update quote and syn. It builds, but the macros don't work yet (tests fail).

The failure seems to be due to use of lifetime `static`. I'm getting errors like
```
error: lifetimes cannot use keyword names
   --> tests/smoke.rs:232:53
    |
232 | fn poll_stream_after_error_stream() -> Result<(), ()> {
    |                                                     ^
```
and
```
error[E0261]: use of undeclared lifetime name `static`
  --> tests/smoke.rs:17:28
   |
17 | fn foo() -> Result<i32, i32> {
   |                            ^ undeclared lifetime
```
and
```
error[E0261]: use of undeclared lifetime name `static`
  --> tests/smoke.rs:42:21
   |
42 | fn _foo5<T: Clone + 'static>(t: T) -> Result<T, i32> {
   |                     ^^^^^^^ undeclared lifetime
```

It seems like something changed in how `'static` should be declared for the output; if somebody knows about this, I'd appreciate some help!